### PR TITLE
feat: Release 1.0.0-alpha.30 with composition schema support and various fixes

### DIFF
--- a/projects/swagger-schematics/CHANGELOG.md
+++ b/projects/swagger-schematics/CHANGELOG.md
@@ -6,6 +6,42 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.30] - 2026-01-27
+
+### ✨ Added
+- **Composition schema support** - `allOf`, `oneOf`, and `anyOf` schemas now generate TypeScript type aliases:
+  - `allOf` → intersection type (`TMyType = TypeA & TypeB`)
+  - `oneOf` / `anyOf` → union type (`TMyType = TypeA | TypeB`)
+  - Type aliases use `T` prefix (consistent with enums), generated as `.type.ts` files
+  - `not` schemas are skipped (no good TypeScript equivalent)
+- New `transformCompositionSchema()` helper for transforming composition schemas
+- Tests for composition schema generation
+- Tests for partial base API file existence (Angular)
+- Tests for interface/enum update behavior (verifying `MergeStrategy.Overwrite`)
+- Tests for `buildScopedApiMethodName` function
+- Tests for `typeMapping` primitive type validation
+
+### 🐛 Fixed
+- `framework` prompt no longer appears when `framework` is set in config file (removed `x-prompt` from schema since config is loaded after prompting phase)
+- Improved `getUrl` method in Angular base service to handle all URL edge cases:
+  - Normalizes multiple slashes in path
+  - Supports empty `apiBaseUrl` for relative paths (Electron apps, same-origin APIs)
+  - Handles base URLs with or without trailing slashes
+  - Preserves path segments in base URL (e.g., `https://example.com/v1/internal`)
+- `typeMapping` now works correctly in types schematic (interface generation) - mapping one enum/interface to another now updates both the type symbol and import
+- **Angular base API generation** now correctly handles partial file existence:
+  - Previously only skipped generation if BOTH files existed
+  - Now generates only the missing file(s) when one exists and the other doesn't
+  - Uses `filter` rule to exclude existing files from template source
+- **`typeMapping` validation** - Primitive type names (`string`, `number`, `boolean`, etc.) are no longer accidentally resolved as schema references even if a schema with that name exists
+- **`buildScopedApiMethodName`** - Fixed case-insensitive comparison consistency by extracting and comparing the same portion being sliced
+- **`isPrimitiveWrapper`** - Now correctly excludes composition schemas (`allOf`, `oneOf`, `anyOf`, `not`) from being identified as primitive wrappers
+
+### ♻️ Changed
+- Removed `MergeStrategy.AllowCreationConflict` from base API generation (no longer needed with proper filtering)
+- Added `ISwaggerSchematicsTypeAliasSchema` interface for type alias schemas
+
+
 ## [1.0.0-alpha.20] - 2026-01-27
 
 ### ✨ Added

--- a/projects/swagger-schematics/__tests__/__fixtures__/swagger/schemas/enums.fixtures.ts
+++ b/projects/swagger-schematics/__tests__/__fixtures__/swagger/schemas/enums.fixtures.ts
@@ -11,11 +11,22 @@ export const CLAIM_TYPE_ENUM_SCHEMA: TSchemaByType = createEnumSchema([1, 2], {
   varnames: ['MS', 'PP']
 });
 
+export const DISTRIBUTION_TYPE_ENUM_SCHEMA: TSchemaByType = createEnumSchema(['TypeA', 'TypeB'], {
+  type: 'string'
+});
+
+export const NULLABLE_OF_DISTRIBUTION_TYPE_ENUM_SCHEMA: TSchemaByType = createEnumSchema(['TypeA', 'TypeB'], {
+  type: 'string',
+  nullable: true
+});
+
 // ============================================================================
 // All Enums (Combined Export)
 // ============================================================================
 
 export const ENUM_SCHEMAS: Record<string, TSchemaByType> = {
   ClaimStatuses: CLAIM_STATUSES_ENUM_SCHEMA,
-  ClaimType: CLAIM_TYPE_ENUM_SCHEMA
+  ClaimType: CLAIM_TYPE_ENUM_SCHEMA,
+  DistributionType: DISTRIBUTION_TYPE_ENUM_SCHEMA,
+  NullableOfDistributionType: NULLABLE_OF_DISTRIBUTION_TYPE_ENUM_SCHEMA
 };

--- a/projects/swagger-schematics/__tests__/__fixtures__/swagger/schemas/models.fixtures.ts
+++ b/projects/swagger-schematics/__tests__/__fixtures__/swagger/schemas/models.fixtures.ts
@@ -80,6 +80,65 @@ export const CLAIM_NOTE_VIEW_DTO_SCHEMA: TSchemaByType = createObjectSchema(
   { description: 'Add a note to a claim', required: ['note'] }
 );
 
+export const TYPE_MAPPING_TEST_DTO_SCHEMA: TSchemaByType = createObjectSchema(
+  {
+    id: { type: 'integer', format: 'int32' },
+    distributionType: { $ref: '#/components/schemas/NullableOfDistributionType' }
+  },
+  { description: 'DTO for testing typeMapping' }
+);
+
+// ============================================================================
+// Composition Schemas (allOf, oneOf, anyOf)
+// ============================================================================
+
+export const BASE_ENTITY_SCHEMA: TSchemaByType = createObjectSchema(
+  {
+    id: { type: 'integer', format: 'int32' },
+    createdAt: { type: 'string', format: 'date-time' }
+  },
+  { description: 'Base entity with common fields' }
+);
+
+export const AUDITABLE_ENTITY_SCHEMA: TSchemaByType = createObjectSchema(
+  {
+    updatedAt: { type: 'string', format: 'date-time', nullable: true },
+    updatedBy: { type: 'string', nullable: true }
+  },
+  { description: 'Auditable fields' }
+);
+
+// allOf - intersection type (combines BaseEntity & AuditableEntity & specific fields)
+export const FULL_CLAIM_DTO_SCHEMA: TSchemaByType = {
+  allOf: [
+    { $ref: '#/components/schemas/BaseEntity' },
+    { $ref: '#/components/schemas/AuditableEntity' },
+    {
+      type: 'object',
+      properties: {
+        claimNumber: { type: 'string' },
+        status: { type: 'string' }
+      }
+    }
+  ]
+} as TSchemaByType;
+
+// oneOf - discriminated union type
+export const NOTIFICATION_SCHEMA: TSchemaByType = {
+  oneOf: [
+    { $ref: '#/components/schemas/IdNameDTO' },
+    { $ref: '#/components/schemas/ClaimDetailDTO' }
+  ]
+} as TSchemaByType;
+
+// anyOf - union type
+export const SEARCH_RESULT_SCHEMA: TSchemaByType = {
+  anyOf: [
+    { $ref: '#/components/schemas/IdNameDTO' },
+    { $ref: '#/components/schemas/CreateNoteDTO' }
+  ]
+} as TSchemaByType;
+
 // ============================================================================
 // All Models (Combined Export)
 // ============================================================================
@@ -89,5 +148,12 @@ export const MODEL_SCHEMAS: Record<string, TSchemaByType> = {
   ClaimDetailDTO: CLAIM_DETAIL_DTO_SCHEMA,
   IdNameDTO: ID_NAME_DTO_SCHEMA,
   CreateNoteDTO: CREATE_NOTE_DTO_SCHEMA,
-  ClaimNoteViewDTO: CLAIM_NOTE_VIEW_DTO_SCHEMA
+  ClaimNoteViewDTO: CLAIM_NOTE_VIEW_DTO_SCHEMA,
+  TypeMappingTestDTO: TYPE_MAPPING_TEST_DTO_SCHEMA,
+  // Composition schemas
+  BaseEntity: BASE_ENTITY_SCHEMA,
+  AuditableEntity: AUDITABLE_ENTITY_SCHEMA,
+  FullClaimDTO: FULL_CLAIM_DTO_SCHEMA,
+  Notification: NOTIFICATION_SCHEMA,
+  SearchResult: SEARCH_RESULT_SCHEMA
 };

--- a/projects/swagger-schematics/__tests__/helpers/factories.ts
+++ b/projects/swagger-schematics/__tests__/helpers/factories.ts
@@ -388,14 +388,15 @@ export const createObjectSchema = (
 };
 
 export const createEnumSchema = (
-  values: number[],
-  options: { varnames?: string[] } = {}
-): ISchemaInteger => ({
-  type: 'integer',
-  format: 'int32',
+  values: (number | string)[],
+  options: { varnames?: string[]; type?: 'integer' | 'string'; nullable?: boolean } = {}
+): TSchemaByType => ({
+  type: options.type ?? 'integer',
+  ...(options.type !== 'string' ? { format: 'int32' } : {}),
   enum: values,
-  ...(options.varnames ? { 'x-enum-varnames': options.varnames } : {})
-});
+  ...(options.varnames ? { 'x-enum-varnames': options.varnames } : {}),
+  ...(options.nullable ? { nullable: true } : {})
+} as TSchemaByType);
 
 // ============================================================================
 // Full Swagger Schema Factory

--- a/projects/swagger-schematics/__tests__/integration/__snapshots__/angular-schematics.spec.ts.snap
+++ b/projects/swagger-schematics/__tests__/integration/__snapshots__/angular-schematics.spec.ts.snap
@@ -162,8 +162,16 @@ exports[`Schematics Integration File Generation should generate expected files 1
   "/test-output/interfaces/id-name-dto.interface.ts",
   "/test-output/interfaces/create-note-dto.interface.ts",
   "/test-output/interfaces/claim-note-view-dto.interface.ts",
+  "/test-output/interfaces/type-mapping-test-dto.interface.ts",
+  "/test-output/interfaces/base-entity.interface.ts",
+  "/test-output/interfaces/auditable-entity.interface.ts",
+  "/test-output/interfaces/full-claim-dto.type.ts",
+  "/test-output/interfaces/notification.type.ts",
+  "/test-output/interfaces/search-result.type.ts",
   "/test-output/enums/claim-statuses.enum.ts",
   "/test-output/enums/claim-type.enum.ts",
+  "/test-output/enums/distribution-type.enum.ts",
+  "/test-output/enums/nullable-of-distribution-type.enum.ts",
 ]
 `;
 

--- a/projects/swagger-schematics/__tests__/integration/__snapshots__/rtk-schematics.spec.ts.snap
+++ b/projects/swagger-schematics/__tests__/integration/__snapshots__/rtk-schematics.spec.ts.snap
@@ -10,8 +10,16 @@ exports[`RTK Query Schematics Integration File Generation should generate expect
   "/test-output/interfaces/id-name-dto.interface.ts",
   "/test-output/interfaces/create-note-dto.interface.ts",
   "/test-output/interfaces/claim-note-view-dto.interface.ts",
+  "/test-output/interfaces/type-mapping-test-dto.interface.ts",
+  "/test-output/interfaces/base-entity.interface.ts",
+  "/test-output/interfaces/auditable-entity.interface.ts",
+  "/test-output/interfaces/full-claim-dto.type.ts",
+  "/test-output/interfaces/notification.type.ts",
+  "/test-output/interfaces/search-result.type.ts",
   "/test-output/enums/claim-statuses.enum.ts",
   "/test-output/enums/claim-type.enum.ts",
+  "/test-output/enums/distribution-type.enum.ts",
+  "/test-output/enums/nullable-of-distribution-type.enum.ts",
   "/th-common/store/api-base.ts",
 ]
 `;

--- a/projects/swagger-schematics/__tests__/integration/__snapshots__/types-schematics.spec.ts.snap
+++ b/projects/swagger-schematics/__tests__/integration/__snapshots__/types-schematics.spec.ts.snap
@@ -27,8 +27,16 @@ exports[`Types Schematics Integration File Generation should generate expected t
   "/test-output/interfaces/id-name-dto.interface.ts",
   "/test-output/interfaces/create-note-dto.interface.ts",
   "/test-output/interfaces/claim-note-view-dto.interface.ts",
+  "/test-output/interfaces/type-mapping-test-dto.interface.ts",
+  "/test-output/interfaces/base-entity.interface.ts",
+  "/test-output/interfaces/auditable-entity.interface.ts",
+  "/test-output/interfaces/full-claim-dto.type.ts",
+  "/test-output/interfaces/notification.type.ts",
+  "/test-output/interfaces/search-result.type.ts",
   "/test-output/enums/claim-statuses.enum.ts",
   "/test-output/enums/claim-type.enum.ts",
+  "/test-output/enums/distribution-type.enum.ts",
+  "/test-output/enums/nullable-of-distribution-type.enum.ts",
 ]
 `;
 

--- a/projects/swagger-schematics/__tests__/integration/angular-schematics.spec.ts
+++ b/projects/swagger-schematics/__tests__/integration/angular-schematics.spec.ts
@@ -134,6 +134,13 @@ describe('Schematics Integration', () => {
       expect(files).toContain(`${ANGULAR_SCHEMATIC_OPTIONS.path}/_api-base-url.token.ts`);
     });
 
+    it('should generate getUrl method that normalizes path slashes', () => {
+      const baseServiceContent = tree.readContent(`${ANGULAR_SCHEMATIC_OPTIONS.path}/_api-base.service.ts`);
+      // Verify the getUrl method normalizes multiple slashes
+      expect(baseServiceContent).toContain(".replace(/\\/+/g, '/')");
+      expect(baseServiceContent).toContain('getUrl(url: string =');
+    });
+
     it('should skip base API generation if files already exist', async () => {
       resetAxiosMocks();
       setupSwaggerMock(ANGULAR_SCHEMATIC_OPTIONS.swaggerSchemaUrl, SWAGGER_SCHEMA);
@@ -152,6 +159,48 @@ describe('Schematics Integration', () => {
 
       expect(baseServiceContent).toBe('// Existing base service');
       expect(baseUrlTokenContent).toBe('// Existing URL token');
+    });
+
+    it('should generate only missing token file when service already exists', async () => {
+      resetAxiosMocks();
+      setupSwaggerMock(ANGULAR_SCHEMATIC_OPTIONS.swaggerSchemaUrl, SWAGGER_SCHEMA);
+
+      // Create a tree with only the service file existing
+      let testTree = createTestTree();
+      testTree.create(`${ANGULAR_SCHEMATIC_OPTIONS.path}/_api-base.service.ts`, '// Existing base service');
+
+      testTree = await runTypesSchematic(ANGULAR_SCHEMATIC_OPTIONS, testTree);
+      const resultTree = await runApiSchematic(ANGULAR_SCHEMATIC_OPTIONS, testTree);
+
+      // The existing service file should NOT be overwritten
+      const baseServiceContent = resultTree.readContent(`${ANGULAR_SCHEMATIC_OPTIONS.path}/_api-base.service.ts`);
+      expect(baseServiceContent).toBe('// Existing base service');
+
+      // The missing token file SHOULD be generated
+      const baseUrlTokenContent = resultTree.readContent(`${ANGULAR_SCHEMATIC_OPTIONS.path}/_api-base-url.token.ts`);
+      expect(baseUrlTokenContent).toContain('API_BASE_URL');
+      expect(baseUrlTokenContent).toContain('InjectionToken');
+    });
+
+    it('should generate only missing service file when token already exists', async () => {
+      resetAxiosMocks();
+      setupSwaggerMock(ANGULAR_SCHEMATIC_OPTIONS.swaggerSchemaUrl, SWAGGER_SCHEMA);
+
+      // Create a tree with only the token file existing
+      let testTree = createTestTree();
+      testTree.create(`${ANGULAR_SCHEMATIC_OPTIONS.path}/_api-base-url.token.ts`, '// Existing URL token');
+
+      testTree = await runTypesSchematic(ANGULAR_SCHEMATIC_OPTIONS, testTree);
+      const resultTree = await runApiSchematic(ANGULAR_SCHEMATIC_OPTIONS, testTree);
+
+      // The existing token file should NOT be overwritten
+      const baseUrlTokenContent = resultTree.readContent(`${ANGULAR_SCHEMATIC_OPTIONS.path}/_api-base-url.token.ts`);
+      expect(baseUrlTokenContent).toBe('// Existing URL token');
+
+      // The missing service file SHOULD be generated
+      const baseServiceContent = resultTree.readContent(`${ANGULAR_SCHEMATIC_OPTIONS.path}/_api-base.service.ts`);
+      expect(baseServiceContent).toContain('ApiBaseService');
+      expect(baseServiceContent).toContain('HttpClient');
     });
   });
 
@@ -185,7 +234,7 @@ describe('Schematics Integration', () => {
       setupSwaggerMock(optionsWithInvalidHelpers.swaggerSchemaUrl, SWAGGER_SCHEMA);
 
       await expect(runFullSchematics(SWAGGER_SCHEMA, optionsWithInvalidHelpers))
-        .rejects.toThrow(/Failed to load template helpers/);
+        .rejects.toThrow(/Template helpers file not found/);
     });
   });
 });

--- a/projects/swagger-schematics/__tests__/integration/types-schematics.spec.ts
+++ b/projects/swagger-schematics/__tests__/integration/types-schematics.spec.ts
@@ -72,4 +72,155 @@ describe('Types Schematics Integration', () => {
       expect(content).toMatchSnapshot();
     });
   });
+
+  describe('File Update Behavior', () => {
+    it('should update existing enum files when schema changes', async () => {
+      resetAxiosMocks();
+      setupSwaggerMock(ANGULAR_SCHEMATIC_OPTIONS.swaggerSchemaUrl, SWAGGER_SCHEMA);
+
+      // Create a tree with an existing enum file with old content
+      let testTree = createTestTree();
+      testTree.create(
+        `${ANGULAR_SCHEMATIC_OPTIONS.path}/enums/claim-statuses.enum.ts`,
+        '// Old enum content that should be replaced'
+      );
+
+      const resultTree = await runTypesSchematic(ANGULAR_SCHEMATIC_OPTIONS, testTree);
+
+      // The enum file should be updated with new content
+      const enumContent = resultTree.readContent(`${ANGULAR_SCHEMATIC_OPTIONS.path}/enums/claim-statuses.enum.ts`);
+      expect(enumContent).not.toContain('// Old enum content');
+      expect(enumContent).toContain('export enum TClaimStatuses');
+    });
+
+    it('should update existing interface files when schema changes', async () => {
+      resetAxiosMocks();
+      setupSwaggerMock(ANGULAR_SCHEMATIC_OPTIONS.swaggerSchemaUrl, SWAGGER_SCHEMA);
+
+      // Create a tree with an existing interface file with old content
+      let testTree = createTestTree();
+      testTree.create(
+        `${ANGULAR_SCHEMATIC_OPTIONS.path}/interfaces/claim-detail-dto.interface.ts`,
+        '// Old interface content that should be replaced\nexport interface IClaimDetailDTO { oldProp: string; }'
+      );
+
+      const resultTree = await runTypesSchematic(ANGULAR_SCHEMATIC_OPTIONS, testTree);
+
+      // The interface file should be updated with new content
+      const interfaceContent = resultTree.readContent(`${ANGULAR_SCHEMATIC_OPTIONS.path}/interfaces/claim-detail-dto.interface.ts`);
+      expect(interfaceContent).not.toContain('// Old interface content');
+      expect(interfaceContent).not.toContain('oldProp');
+      expect(interfaceContent).toContain('export interface IClaimDetailDTO');
+    });
+
+    it('should update multiple existing files in a single run', async () => {
+      resetAxiosMocks();
+      setupSwaggerMock(ANGULAR_SCHEMATIC_OPTIONS.swaggerSchemaUrl, SWAGGER_SCHEMA);
+
+      // Create a tree with multiple existing files
+      let testTree = createTestTree();
+      testTree.create(
+        `${ANGULAR_SCHEMATIC_OPTIONS.path}/enums/claim-statuses.enum.ts`,
+        '// Old ClaimStatuses enum'
+      );
+      testTree.create(
+        `${ANGULAR_SCHEMATIC_OPTIONS.path}/enums/claim-type.enum.ts`,
+        '// Old ClaimType enum'
+      );
+      testTree.create(
+        `${ANGULAR_SCHEMATIC_OPTIONS.path}/interfaces/id-name-dto.interface.ts`,
+        '// Old IdNameDTO interface'
+      );
+
+      const resultTree = await runTypesSchematic(ANGULAR_SCHEMATIC_OPTIONS, testTree);
+
+      // All files should be updated
+      const claimStatusesContent = resultTree.readContent(`${ANGULAR_SCHEMATIC_OPTIONS.path}/enums/claim-statuses.enum.ts`);
+      const claimTypeContent = resultTree.readContent(`${ANGULAR_SCHEMATIC_OPTIONS.path}/enums/claim-type.enum.ts`);
+      const idNameDtoContent = resultTree.readContent(`${ANGULAR_SCHEMATIC_OPTIONS.path}/interfaces/id-name-dto.interface.ts`);
+
+      expect(claimStatusesContent).toContain('export enum TClaimStatuses');
+      expect(claimTypeContent).toContain('export enum TClaimType');
+      expect(idNameDtoContent).toContain('export interface IIdNameDTO');
+    });
+  });
+
+  describe('Composition Schema Generation', () => {
+    it('should generate type alias for allOf schemas', () => {
+      const content = tree.readContent(`${ANGULAR_SCHEMATIC_OPTIONS.path}/interfaces/full-claim-dto.type.ts`);
+      
+      // Should be a type alias with T prefix, not interface with I prefix
+      expect(content).toContain('export type TFullClaimDTO =');
+      // Should be intersection type with &
+      expect(content).toContain('&');
+      // Should import referenced types
+      expect(content).toContain('IBaseEntity');
+      expect(content).toContain('IAuditableEntity');
+    });
+
+    it('should generate type alias for oneOf schemas', () => {
+      const content = tree.readContent(`${ANGULAR_SCHEMATIC_OPTIONS.path}/interfaces/notification.type.ts`);
+      
+      // Should be a type alias with T prefix
+      expect(content).toContain('export type TNotification =');
+      expect(content).toContain('|');
+      // Should import referenced types
+      expect(content).toContain('IIdNameDTO');
+      expect(content).toContain('IClaimDetailDTO');
+    });
+
+    it('should generate type alias for anyOf schemas', () => {
+      const content = tree.readContent(`${ANGULAR_SCHEMATIC_OPTIONS.path}/interfaces/search-result.type.ts`);
+      
+      // Should be a type alias with T prefix
+      expect(content).toContain('export type TSearchResult =');
+      expect(content).toContain('|');
+    });
+
+    it('should create type files for composition schemas', () => {
+      expect(files).toContain(`${ANGULAR_SCHEMATIC_OPTIONS.path}/interfaces/full-claim-dto.type.ts`);
+      expect(files).toContain(`${ANGULAR_SCHEMATIC_OPTIONS.path}/interfaces/notification.type.ts`);
+      expect(files).toContain(`${ANGULAR_SCHEMATIC_OPTIONS.path}/interfaces/search-result.type.ts`);
+    });
+  });
+
+  describe('typeMapping option', () => {
+    let typeMappingTree: UnitTestTree;
+
+    beforeAll(async () => {
+      resetAxiosMocks();
+      setupSwaggerMock(ANGULAR_SCHEMATIC_OPTIONS.swaggerSchemaUrl, SWAGGER_SCHEMA);
+      
+      const optionsWithTypeMapping = {
+        ...ANGULAR_SCHEMATIC_OPTIONS,
+        typeMapping: {
+          'NullableOfDistributionType': 'DistributionType'
+        }
+      };
+      
+      typeMappingTree = await runTypesSchematic(optionsWithTypeMapping, createTestTree());
+    });
+
+    it('should map NullableOfDistributionType to DistributionType with | null in interface', () => {
+      const content = typeMappingTree.readContent(`${ANGULAR_SCHEMATIC_OPTIONS.path}/interfaces/type-mapping-test-dto.interface.ts`);
+      
+      // Should use DistributionType import, not NullableOfDistributionType
+      expect(content).toContain("import { TDistributionType }");
+      expect(content).toContain("from '../enums/distribution-type.enum'");
+      
+      // Should NOT import from nullable-of-distribution-type
+      expect(content).not.toContain('nullable-of-distribution-type');
+      
+      // Should have | null for the nullable type
+      expect(content).toContain('TDistributionType | null');
+    });
+
+    it('should use original NullableOfDistributionType import when typeMapping is not set', () => {
+      const content = tree.readContent(`${ANGULAR_SCHEMATIC_OPTIONS.path}/interfaces/type-mapping-test-dto.interface.ts`);
+      
+      // Without typeMapping, should use the original NullableOfDistributionType
+      expect(content).toContain("import { TNullableOfDistributionType }");
+      expect(content).toContain("from '../enums/nullable-of-distribution-type.enum'");
+    });
+  });
 });

--- a/projects/swagger-schematics/__tests__/unit/api-helper.spec.ts
+++ b/projects/swagger-schematics/__tests__/unit/api-helper.spec.ts
@@ -1,5 +1,5 @@
 import '../helpers/matchers';
-import { IParsedApiSchema, transformSwaggerSchema } from '../../api/helpers/api.helper';
+import { IParsedApiSchema, transformSwaggerSchema, buildScopedApiMethodName } from '../../api/helpers/api.helper';
 import { SWAGGER_SCHEMA, MOCK_GROUP } from '../__fixtures__/swagger/full-schema.fixture';
 
 describe('API Helper - transformSwaggerSchema', () => {
@@ -82,5 +82,50 @@ describe('API Helper - transformSwaggerSchema', () => {
       // Snapshot of the full parsed structure for regression testing
       expect(parsedSchema).toMatchSnapshot();
     });
+  });
+});
+
+describe('buildScopedApiMethodName', () => {
+  it('should prefix method name with camelized tag name', () => {
+    expect(buildScopedApiMethodName('getById', 'Claim')).toBe('claimGetById');
+    expect(buildScopedApiMethodName('create', 'User')).toBe('userCreate');
+  });
+
+  it('should handle hyphenated tag names', () => {
+    expect(buildScopedApiMethodName('getAll', 'user-profile')).toBe('userProfileGetAll');
+    expect(buildScopedApiMethodName('update', 'api-settings')).toBe('apiSettingsUpdate');
+  });
+
+  it('should avoid redundant prefix when suffix starts with prefix (case-insensitive)', () => {
+    // "UsersGet" starts with "users" (case-insensitive), should become "usersGet"
+    expect(buildScopedApiMethodName('UsersGet', 'users')).toBe('usersGet');
+    expect(buildScopedApiMethodName('usersGet', 'users')).toBe('usersGet');
+    // classify('USERSGET') = 'USERSGET', so remaining part after prefix removal is 'GET'
+    expect(buildScopedApiMethodName('USERSGET', 'users')).toBe('usersGET');
+  });
+
+  it('should handle mixed case correctly when removing redundant prefix', () => {
+    // The suffix "UsersGetAll" starts with "Users" which matches "users" case-insensitively
+    expect(buildScopedApiMethodName('UsersGetAll', 'users')).toBe('usersGetAll');
+    expect(buildScopedApiMethodName('ClaimGet', 'claim')).toBe('claimGet');
+    expect(buildScopedApiMethodName('CLAIMGet', 'claim')).toBe('claimGet');
+  });
+
+  it('should not remove prefix when suffix does not start with it', () => {
+    expect(buildScopedApiMethodName('getById', 'users')).toBe('usersGetById');
+    expect(buildScopedApiMethodName('create', 'claim')).toBe('claimCreate');
+  });
+
+  it('should not remove prefix when suffix equals prefix exactly', () => {
+    // When suffix is exactly the prefix (after classification), keep both
+    expect(buildScopedApiMethodName('users', 'users')).toBe('usersUsers');
+    expect(buildScopedApiMethodName('claim', 'claim')).toBe('claimClaim');
+  });
+
+  it('should handle partial prefix matches correctly', () => {
+    // "UserGet" does NOT start with "users" (missing 's'), should not remove
+    expect(buildScopedApiMethodName('UserGet', 'users')).toBe('usersUserGet');
+    // "Use" does NOT start with "users", should not remove
+    expect(buildScopedApiMethodName('UseData', 'users')).toBe('usersUseData');
   });
 });

--- a/projects/swagger-schematics/__tests__/unit/transform-type.spec.ts
+++ b/projects/swagger-schematics/__tests__/unit/transform-type.spec.ts
@@ -249,6 +249,101 @@ describe('Transform Type', () => {
       expect(result[0]).toBe('number | null');
       expect(result[1]).toBeUndefined();
     });
+
+    it('should not resolve primitive type names as schema references even if schema exists', () => {
+      // Edge case: schema named "String" exists, but mapping to 'string' should treat it as primitive
+      const swagger = createSwaggerSchema({
+        MyType: { type: 'object' },
+        String: { type: 'object', properties: { value: { type: 'string' } } }
+      });
+      const options: ITransformTypeOptions = {
+        typeMapping: { 'MyType': 'string' }
+      };
+
+      const result = transformType(
+        { $ref: '#/components/schemas/MyType' },
+        swagger,
+        options
+      );
+
+      // Should be primitive 'string', not 'IString' interface
+      expect(result[0]).toBe('string');
+      expect(result[1]).toBeUndefined();
+    });
+
+    it('should not resolve lowercase custom type aliases as schema references', () => {
+      const swagger = createSwaggerSchema({
+        MyGuid: { type: 'object' },
+        guid: { type: 'object', properties: {} } // lowercase schema that shouldn't match
+      });
+      const options: ITransformTypeOptions = {
+        typeMapping: { 'MyGuid': 'guid' } // lowercase mapping
+      };
+
+      const result = transformType(
+        { $ref: '#/components/schemas/MyGuid' },
+        swagger,
+        options
+      );
+
+      // Should treat 'guid' as a custom primitive alias, not resolve to 'Iguid'
+      expect(result[0]).toBe('guid');
+      expect(result[1]).toBeUndefined();
+    });
+
+    it('should resolve PascalCase mapped values as schema references when schema exists', () => {
+      const swagger = createSwaggerSchema({
+        NullableUserDTO: { type: 'object', nullable: true, properties: { id: { type: 'integer' } } },
+        UserDTO: { type: 'object', properties: { id: { type: 'integer' } } }
+      });
+      const options: ITransformTypeOptions = {
+        typeMapping: { 'NullableUserDTO': 'UserDTO' }
+      };
+
+      const result = transformType(
+        { $ref: '#/components/schemas/NullableUserDTO' },
+        swagger,
+        options
+      );
+
+      // Should resolve to the mapped schema with nullable preserved from original
+      expect(result[0]).toBe('IUserDTO | null');
+      expect(result[1]).toEqual({
+        type: 'interface',
+        importSymbol: 'IUserDTO',
+        fileName: 'user-dto'
+      });
+    });
+
+    it('should handle all TypeScript primitive type names correctly', () => {
+      const swagger = createSwaggerSchema({
+        Type1: { type: 'object' },
+        Type2: { type: 'object' },
+        Type3: { type: 'object' },
+        Type4: { type: 'object' },
+        Type5: { type: 'object' },
+        // Schemas with primitive names (edge case)
+        Number: { type: 'object', properties: {} },
+        Boolean: { type: 'object', properties: {} },
+        Any: { type: 'object', properties: {} }
+      });
+      const options: ITransformTypeOptions = {
+        typeMapping: {
+          'Type1': 'number',
+          'Type2': 'boolean',
+          'Type3': 'any',
+          'Type4': 'unknown',
+          'Type5': 'void'
+        }
+      };
+
+      // All should be treated as primitives, not resolved to schemas
+      expect(transformType({ $ref: '#/components/schemas/Type1' }, swagger, options)[0]).toBe('number');
+      expect(transformType({ $ref: '#/components/schemas/Type2' }, swagger, options)[0]).toBe('boolean');
+      expect(transformType({ $ref: '#/components/schemas/Type3' }, swagger, options)[0]).toBe('any');
+      expect(transformType({ $ref: '#/components/schemas/Type4' }, swagger, options)[0]).toBe('unknown');
+      expect(transformType({ $ref: '#/components/schemas/Type5' }, swagger, options)[0]).toBe('void');
+    });
   });
 
   describe('parseRefToSymbol', () => {
@@ -332,6 +427,30 @@ describe('Transform Type', () => {
 
       expect(result[0]).toBe('IUserDTO');
       expect(result[1]?.type).toBe('interface');
+    });
+
+    it('should not inline schemas with composition even if they have a primitive type', () => {
+      // A schema that has both 'type' and 'allOf' should not be treated as primitive wrapper
+      const swagger = createSwaggerSchema({
+        ComposedString: { 
+          type: 'string', 
+          allOf: [{ $ref: '#/components/schemas/BaseType' }] 
+        },
+        ComposedWithOneOf: {
+          type: 'integer',
+          oneOf: [{ type: 'integer' }, { type: 'string' }]
+        },
+        BaseType: { type: 'object', properties: {} }
+      });
+
+      // Should NOT be inlined as primitive, should be treated as interface
+      const result1 = parseRefToSymbol({ $ref: '#/components/schemas/ComposedString' }, swagger);
+      expect(result1[0]).toBe('IComposedString');
+      expect(result1[1]?.type).toBe('interface');
+
+      const result2 = parseRefToSymbol({ $ref: '#/components/schemas/ComposedWithOneOf' }, swagger);
+      expect(result2[0]).toBe('IComposedWithOneOf');
+      expect(result2[1]?.type).toBe('interface');
     });
 
     it('should add | null for nullable object schemas', () => {

--- a/projects/swagger-schematics/api/helpers/angular-template.helper.ts
+++ b/projects/swagger-schematics/api/helpers/angular-template.helper.ts
@@ -3,8 +3,9 @@ import { IParsedApiItem } from '../../types/utils/params';
 /**
  * Build Angular HttpClient call arguments (everything after the URL)
  * Handles the different argument patterns for GET, POST, PUT, DELETE
+ * Returns an array of argument strings for flexible template formatting
  */
-export function buildAngularHttpCallArgs(item: IParsedApiItem): string {
+export function buildAngularHttpCallArgs(item: IParsedApiItem): string[] {
     const { apiMethodType, bodyFormatted, queryParamsFormatted } = item;
     const parts: string[] = [];
 
@@ -33,5 +34,5 @@ export function buildAngularHttpCallArgs(item: IParsedApiItem): string {
         }
     }
 
-    return parts.join(',\n      ');
+    return parts;
 }

--- a/projects/swagger-schematics/api/helpers/api.helper.ts
+++ b/projects/swagger-schematics/api/helpers/api.helper.ts
@@ -43,10 +43,13 @@ export interface IParsedSchemaItem {
 export const buildScopedApiMethodName = (apiMethodName: string, tagName: string): string => {
     const prefix = camelize(tagName.replace(/-/g, ' '));
     const suffix = classify(apiMethodName);
+    
     // Avoid redundant prefix (e.g., "usersGetUsers" -> "usersGet")
-    const prefixLower = prefix.toLowerCase();
-    const suffixLower = suffix.toLowerCase();
-    if (suffixLower.startsWith(prefixLower) && suffixLower.length > prefixLower.length) {
+    // Extract the portion of suffix that could match the prefix (same length as prefix)
+    const suffixPrefix = suffix.slice(0, prefix.length);
+    
+    // Compare case-insensitively, then slice at the consistent position
+    if (suffixPrefix.toLowerCase() === prefix.toLowerCase() && suffix.length > prefix.length) {
         return prefix + suffix.slice(prefix.length);
     }
     return prefix + suffix;

--- a/projects/swagger-schematics/api/helpers/base-api-rules.ts
+++ b/projects/swagger-schematics/api/helpers/base-api-rules.ts
@@ -1,7 +1,7 @@
 import {
     apply,
     applyTemplates,
-    MergeStrategy,
+    filter,
     mergeWith,
     move,
     noop,
@@ -35,6 +35,7 @@ export function generateBaseApiRule(
 
 /**
  * Generate Angular base API services (api-base.service.ts and api-base-url.token.ts)
+ * Only generates files that don't already exist.
  */
 function generateAngularBaseApiRule(
     tree: Tree,
@@ -48,20 +49,35 @@ function generateAngularBaseApiRule(
 
     const parsed = parseName(basePath, 'ApiBase');
     
-    // Check if base API files already exist
+    // Check which base API files already exist
     const apiBaseServicePath = `${parsed.path}/_api-base.service.ts`;
     const apiBaseUrlTokenPath = `${parsed.path}/_api-base-url.token.ts`;
     
     const apiBaseServiceExists = tree.exists(apiBaseServicePath);
     const apiBaseUrlTokenExists = tree.exists(apiBaseUrlTokenPath);
     
-    // If both files exist, skip generation
+    // If both files exist, skip generation entirely
     if (apiBaseServiceExists && apiBaseUrlTokenExists) {
         return noop();
     }
 
-    // Generate base API files
+    // Build a set of existing file names to filter out (with .template suffix for template matching)
+    const existingTemplateFiles = new Set<string>();
+    if (apiBaseServiceExists) {
+        existingTemplateFiles.add('_api-base.service.ts.template');
+    }
+    if (apiBaseUrlTokenExists) {
+        existingTemplateFiles.add('_api-base-url.token.ts.template');
+    }
+
+    // Generate only the missing base API files
     const baseApiSource = apply(baseApiTemplates, [
+        // Filter out templates for files that already exist
+        // Note: filter runs BEFORE applyTemplates, so paths still have .template suffix
+        filter(path => {
+            const fileName = path.split('/').pop() || '';
+            return !existingTemplateFiles.has(fileName);
+        }),
         applyTemplates({
             ...config,
             ...strings,
@@ -69,11 +85,12 @@ function generateAngularBaseApiRule(
         move(parsed.path)
     ]);
 
-    return mergeWith(baseApiSource, MergeStrategy.AllowCreationConflict);
+    return mergeWith(baseApiSource);
 }
 
 /**
  * Generate RTK base API (api-base.ts)
+ * Only generates the file if it doesn't already exist.
  */
 function generateRtkBaseApiRule(
     tree: Tree,
@@ -94,7 +111,7 @@ function generateRtkBaseApiRule(
     
     const parsed = parseName(dirPath, fileName.replace('.ts', ''));
 
-    // Generate base API file
+    // Generate base API file (file is guaranteed not to exist at this point)
     const baseApiSource = apply(baseApiTemplates, [
         applyTemplates({
             ...config,
@@ -103,5 +120,5 @@ function generateRtkBaseApiRule(
         move(parsed.path)
     ]);
 
-    return mergeWith(baseApiSource, MergeStrategy.AllowCreationConflict);
+    return mergeWith(baseApiSource);
 }

--- a/projects/swagger-schematics/api/helpers/import-path.helper.ts
+++ b/projects/swagger-schematics/api/helpers/import-path.helper.ts
@@ -40,8 +40,9 @@ export function getBaseApiImportPath(
         if (aliasPath) {
             return aliasPath;
         }
-    } catch {
-        // Ignore errors, fall back to relative path
+    } catch (error) {
+        // Log warning for debugging - tsconfig errors won't break generation
+        console.warn(`Warning: Could not load tsconfig.json for path alias resolution: ${(error as Error).message}. Using relative imports.`);
     }
     
     // Fall back to relative import

--- a/projects/swagger-schematics/api/index.ts
+++ b/projects/swagger-schematics/api/index.ts
@@ -23,12 +23,20 @@ import { getBaseApiImportPath } from './helpers/import-path.helper';
 import { generateBaseApiRule, DEFAULT_RTK_BASE_API_PATH } from './helpers/base-api-rules';
 import * as path from 'path';
 
+import { existsSync } from 'fs';
+
 /**
  * Load custom template helpers from a JavaScript file
  */
 function loadTemplateHelpers(helpersPath: string): Record<string, unknown> {
+    const absolutePath = path.resolve(process.cwd(), helpersPath);
+    
+    // Check if file exists first
+    if (!existsSync(absolutePath)) {
+        throw new Error(`Template helpers file not found: '${absolutePath}'`);
+    }
+    
     try {
-        const absolutePath = path.resolve(process.cwd(), helpersPath);
         // Clear require cache to ensure fresh load
         delete require.cache[require.resolve(absolutePath)];
         const helpers = require(absolutePath);

--- a/projects/swagger-schematics/api/schema.json
+++ b/projects/swagger-schematics/api/schema.json
@@ -31,16 +31,8 @@
     },
     "framework": {
       "type": "string",
-      "description": "Target framework for generated API code.",
-      "enum": ["angular", "react-rtk"],
-      "x-prompt": {
-        "message": "Which framework would you like to generate API code for?",
-        "type": "list",
-        "items": [
-          { "value": "angular", "label": "Angular (HttpClient services)" },
-          { "value": "react-rtk", "label": "React RTK Query (API slices)" }
-        ]
-      }
+      "description": "Target framework for generated API code: 'angular' or 'react-rtk'.",
+      "enum": ["angular", "react-rtk"]
     },
     "scopeEndpointsWithTags": {
       "type": "boolean",

--- a/projects/swagger-schematics/api/templates/angular/api-service/__name@dasherize__-api.service.ts.template
+++ b/projects/swagger-schematics/api/templates/angular/api-service/__name@dasherize__-api.service.ts.template
@@ -17,9 +17,9 @@ export class <%= classify(name) %>ApiService extends ApiBaseService {
   let httpCallArgs = buildHttpCallArgs(item);
 %>
   <%= item.apiMethodName %>(<%= item.apiMethodParams %>): Observable<<%= item.responseTypeSymbol %>> {
-<% if (httpCallArgs) { %>    return this.httpClient.<%= item.requestMethod %><<%= item.responseTypeSymbol %>>(
+<% if (httpCallArgs.length > 0) { %>    return this.httpClient.<%= item.requestMethod %><<%= item.responseTypeSymbol %>>(
       this.getUrl(<%= item.apiUrlFormatted %>),
-      <%= httpCallArgs %>
+      <%= httpCallArgs.join(',\n      ') %>
     );
 <% } else { %>    return this.httpClient.<%= item.requestMethod %><<%= item.responseTypeSymbol %>>(
       this.getUrl(<%= item.apiUrlFormatted %>)

--- a/projects/swagger-schematics/api/templates/angular/base-api/_api-base.service.ts.template
+++ b/projects/swagger-schematics/api/templates/angular/base-api/_api-base.service.ts.template
@@ -6,16 +6,16 @@ import { API_BASE_URL } from './_api-base-url.token';
 export abstract class ApiBaseService {
   protected readonly httpClient = inject(HttpClient);
   protected readonly apiBaseUrl = inject(API_BASE_URL);
-  protected readonly apiUrl = new URL('api', this.apiBaseUrl);
   abstract readonly endpoint: string;
 
-  constructor() {
-    if (!this.apiBaseUrl) {
-      throw new Error('API_BASE_URL is not provided');
-    }
-  }
-
   getUrl(url: string = ''): string {
-    return `${this.apiUrl}/${this.endpoint}${url ? `/${url}` : ''}`;
+    const path = ['api', this.endpoint, url]
+      .filter(Boolean)
+      .join('/')
+      .replace(/\/+/g, '/');
+
+    return this.apiBaseUrl
+      ? `${this.apiBaseUrl.replace(/\/$/, '')}/${path}`
+      : `/${path}`;
   }
 }

--- a/projects/swagger-schematics/helpers/config.ts
+++ b/projects/swagger-schematics/helpers/config.ts
@@ -6,7 +6,6 @@ type swaggerSchemaKeys = keyof SwaggerApiSchema;
 
 /** Default configuration values */
 const DEFAULT_CONFIG: Partial<SwaggerApiSchema> = {
-    framework: 'angular',
     scopeEndpointsWithTags: false,
 };
 

--- a/projects/swagger-schematics/helpers/tsconfig.ts
+++ b/projects/swagger-schematics/helpers/tsconfig.ts
@@ -22,22 +22,48 @@ function readFileContent(filePath: string, tree?: Tree): string {
 }
 
 /**
+ * Parse tsconfig JSON content with error handling
+ */
+function parseTsConfig(filePath: string, content: string): Record<string, any> {
+  const result = parseConfigFileTextToJson(filePath, content);
+  
+  if (result.error) {
+    const errorMessage = result.error.messageText;
+    const message = typeof errorMessage === 'string' 
+      ? errorMessage 
+      : errorMessage.messageText;
+    throw new Error(`Invalid tsconfig at '${filePath}': ${message}`);
+  }
+  
+  if (!result.config) {
+    throw new Error(`Failed to parse tsconfig at '${filePath}': No configuration found`);
+  }
+  
+  return result.config;
+}
+
+/**
  * Load tsconfig.json and parse path aliases
  * @param tsConfigPath - Path to tsconfig.json
  * @param tree - Optional schematic tree for reading from virtual filesystem
  */
 export function loadTsConfig(tsConfigPath: string, tree?: Tree): TsConfigResult {
   const configFileContent = readFileContent(tsConfigPath, tree);
-  let configJson = parseConfigFileTextToJson(tsConfigPath, configFileContent).config;
+  let configJson = parseTsConfig(tsConfigPath, configFileContent);
 
   if (configJson.extends) {
     const extendsPath = path.resolve(path.dirname(tsConfigPath), configJson.extends);
     const extendsConfigContent = readFileContent(extendsPath, tree);
-    const extendsConfigJson = parseConfigFileTextToJson(extendsPath, extendsConfigContent).config;
+    const extendsConfigJson = parseTsConfig(extendsPath, extendsConfigContent);
     
+    // Deep merge compilerOptions to preserve options from both configs
     configJson = {
       ...extendsConfigJson,
       ...configJson,
+      compilerOptions: {
+        ...extendsConfigJson.compilerOptions,
+        ...configJson.compilerOptions,
+      },
     };
   }
 
@@ -55,15 +81,17 @@ export function loadTsConfig(tsConfigPath: string, tree?: Tree): TsConfigResult 
  */
 export function resolvePathToAlias(filePath: string, paths: Record<string, string[]>): string | null {
   for (const [aliasPattern, targetPaths] of Object.entries(paths)) {
-    // Get the target directory (e.g., "src/*" -> "src/")
-    const targetPath = targetPaths[0];
-    const targetPrefix = targetPath.replace('*', '');
-    
-    // Check if the file path starts with the target prefix
-    if (filePath.startsWith(targetPrefix)) {
-      // Replace the target prefix with the alias (e.g., "src/stores/..." -> "@/stores/...")
-      const aliasPrefix = aliasPattern.replace('*', '');
-      return aliasPrefix + filePath.substring(targetPrefix.length);
+    // Iterate through all target paths (tsconfig supports multiple fallback paths)
+    for (const targetPath of targetPaths) {
+      // Get the target directory (e.g., "src/*" -> "src/")
+      const targetPrefix = targetPath.replace('*', '');
+      
+      // Check if the file path starts with the target prefix
+      if (filePath.startsWith(targetPrefix)) {
+        // Replace the target prefix with the alias (e.g., "src/stores/..." -> "@/stores/...")
+        const aliasPrefix = aliasPattern.replace('*', '');
+        return aliasPrefix + filePath.substring(targetPrefix.length);
+      }
     }
   }
 

--- a/projects/swagger-schematics/interfaces/swagger-schematics/schema.ts
+++ b/projects/swagger-schematics/interfaces/swagger-schematics/schema.ts
@@ -1,4 +1,4 @@
-import { ISchemaProperties } from "../version_3_1/swagger.interface";
+import { ISchemaProperties, TSchemaByType } from "../version_3_1/swagger.interface";
 
 export interface ISwaggerSchematicsBaseSchema {
     name: string;
@@ -21,4 +21,10 @@ export interface ISwaggerSchematicsInterfaceSchema extends ISwaggerSchematicsBas
     };
 }
 
-export type TSwaggerSchematicsSchema = ISwaggerSchematicsEnumSchema | ISwaggerSchematicsInterfaceSchema;
+export interface ISwaggerSchematicsTypeAliasSchema extends ISwaggerSchematicsBaseSchema {
+    name: string;
+    type: 'type-alias';
+    data: TSchemaByType;
+}
+
+export type TSwaggerSchematicsSchema = ISwaggerSchematicsEnumSchema | ISwaggerSchematicsInterfaceSchema | ISwaggerSchematicsTypeAliasSchema;

--- a/projects/swagger-schematics/package.json
+++ b/projects/swagger-schematics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-schematics",
-  "version": "1.0.0-alpha.20",
+  "version": "1.0.0-alpha.30",
   "description": "Schematics types and API generator via Swagger scheme",
   "scripts": {
     "prebuild": "dtsgen --out schema.d.ts **/schema.json",

--- a/projects/swagger-schematics/types/helpers/template.helper.ts
+++ b/projects/swagger-schematics/types/helpers/template.helper.ts
@@ -1,8 +1,9 @@
 import { buildRelativePath } from "@schematics/angular/utility/find-module";
-import { IImportRef, isNullable, transformType } from "../utils/transform-type";
-import { ISchemaProperties, ISwaggerSchema } from "../../interfaces/version_3_1/swagger.interface";
+import { IImportRef, ITransformTypeOptions, isNullable, transformType, getCompositionImports } from "../utils/transform-type";
+import { ISchemaProperties, ISwaggerSchema, TSchemaByType } from "../../interfaces/version_3_1/swagger.interface";
+import { isAllOf, isOneOf, isAnyOf } from "../utils/transform-type";
 
-export function transformProperties(properties: ISchemaProperties, swagger: ISwaggerSchema): {
+export function transformProperties(properties: ISchemaProperties, swagger: ISwaggerSchema, options?: ITransformTypeOptions): {
     propertiesContent: Array<[string, string]>;
     refs: IImportRef[];
 } {
@@ -11,7 +12,7 @@ export function transformProperties(properties: ISchemaProperties, swagger: ISwa
 
     for (const propertyKey in properties) {
         const property = properties[propertyKey];
-        const [typeSymbol, importRef] = transformType(property, swagger);
+        const [typeSymbol, importRef] = transformType(property, swagger, options);
         if (importRef) {
             refs.push(importRef);
         }
@@ -57,4 +58,56 @@ export function interfacePropertyLine(interfaceProperties: Array<[string, string
 export function buildImport(fromPath: string, toPath: string, symbolName: string) {
     const relativePath = buildRelativePath(fromPath, toPath);
     return `import { ${symbolName} } from '${relativePath}';`;
+}
+
+/**
+ * Transform a composition schema (allOf, oneOf, anyOf) into a type expression and import refs
+ */
+export function transformCompositionSchema(schema: TSchemaByType, swagger: ISwaggerSchema, options?: ITransformTypeOptions): {
+    typeExpression: string;
+    importRefs: IImportRef[];
+} {
+    const importRefs = getCompositionImports(schema, swagger, options);
+    
+    if (isAllOf(schema)) {
+        // allOf -> intersection type (A & B & C)
+        const types = schema.allOf.map(s => {
+            const [typeSymbol] = transformType(s, swagger, options);
+            return typeSymbol;
+        });
+        return {
+            typeExpression: types.join(' & '),
+            importRefs: removeImportDuplicates(importRefs)
+        };
+    }
+    
+    if (isOneOf(schema)) {
+        // oneOf -> union type (A | B | C)
+        const types = schema.oneOf.map(s => {
+            const [typeSymbol] = transformType(s, swagger, options);
+            return typeSymbol;
+        });
+        return {
+            typeExpression: types.join(' | '),
+            importRefs: removeImportDuplicates(importRefs)
+        };
+    }
+    
+    if (isAnyOf(schema)) {
+        // anyOf -> union type (A | B | C)
+        const types = schema.anyOf.map(s => {
+            const [typeSymbol] = transformType(s, swagger, options);
+            return typeSymbol;
+        });
+        return {
+            typeExpression: types.join(' | '),
+            importRefs: removeImportDuplicates(importRefs)
+        };
+    }
+    
+    // Fallback for 'not' or unknown composition
+    return {
+        typeExpression: 'unknown',
+        importRefs: []
+    };
 }

--- a/projects/swagger-schematics/types/index.ts
+++ b/projects/swagger-schematics/types/index.ts
@@ -10,13 +10,13 @@ import {strings} from '@angular-devkit/core';
 import {parseName} from '@schematics/angular/utility/parse-name';
 import {enums, templateHelpers} from "./utils";
 import {TSchemaByType, ISwaggerSchema, TSchemaWithType} from "../interfaces/version_3_1/swagger.interface";
-import { isComposition } from "./utils/transform-type";
+import { isComposition, isNot } from "./utils/transform-type";
 import axios, {AxiosResponse} from "axios";
 import {dasherize} from "@angular-devkit/core/src/utils/strings";
 import {parseBuffer as editorconfigParseBuffer} from 'editorconfig';
 import { IRef } from '../interfaces/version_3_1/ref.interface';
 import { TSwaggerSchematicsSchema } from '../interfaces/swagger-schematics/schema';
-import { removeImportDuplicates, transformProperties } from './helpers/template.helper';
+import { removeImportDuplicates, transformProperties, transformCompositionSchema } from './helpers/template.helper';
 import { getOpenapiSchematicsConfig } from '../helpers/config';
 
 export default function(options: SwaggerSchema): Rule {
@@ -52,10 +52,17 @@ export default function(options: SwaggerSchema): Rule {
         
         const typedSchema = schema as TSchemaByType;
         
-        // Skip composition schemas for now (allOf, oneOf, anyOf, not)
-        // They will be handled differently in the future
+        // Handle composition schemas (allOf, oneOf, anyOf)
+        // Skip 'not' schemas as they don't have a good TypeScript equivalent
         if (isComposition(typedSchema)) {
-            return;
+            if (isNot(typedSchema)) {
+                return; // Skip 'not' schemas
+            }
+            return {
+                name: schemaKey,
+                type: 'type-alias' as const,
+                data: schemas[schemaKey]
+            } as TSwaggerSchematicsSchema;
         }
         
         // Check if it's an enum (integer or string with enum values)
@@ -71,6 +78,7 @@ export default function(options: SwaggerSchema): Rule {
 
       const interfaceTemplates = url('./templates/interface');
       const enumTemplates = url('./templates/enum');
+      const typeAliasTemplates = url('./templates/type-alias');
 
       let finalRule: Rule | undefined;
       parsedSchemas.forEach(schemaData => {
@@ -94,10 +102,37 @@ export default function(options: SwaggerSchema): Rule {
                   }),
                   move(parsed.path)
               ]);
+          } else if (schemaData.type === 'type-alias') {
+              // Handle composition schemas (allOf, oneOf, anyOf)
+              const parsed = parseName(`${openApiSchematicsConfig.path}/interfaces`, schemaData.name);
+              const { typeExpression, importRefs: compositionRefs } = transformCompositionSchema(
+                  schemaData.data as TSchemaByType,
+                  swagger.data,
+                  { typeMapping: openApiSchematicsConfig.typeMapping }
+              );
+              // Filter out self-references
+              const importRefs = compositionRefs.filter(refItem => refItem.importSymbol !== `I${parsed.name}`);
+              itemSource = apply(typeAliasTemplates, [
+                  applyTemplates({
+                      ...openApiSchematicsConfig,
+                      ...strings,
+                      ...templateHelpers,
+                      name: parsed.name,
+                      path: parsed.path,
+                      optionsPath: openApiSchematicsConfig.path,
+                      sourcePath: `${parsed.path}/${dasherize(parsed.name)}`,
+                      typeExpression,
+                      importRefs,
+                      indentSize
+                  }),
+                  move(parsed.path)
+              ]);
           } else {
             const parsed = parseName(`${openApiSchematicsConfig.path}/interfaces`, schemaData.name);
             const schemaProperties = schemaData.data.properties
-            const {propertiesContent, refs} = transformProperties(!!schemaProperties ? schemaProperties : {}, swagger.data);
+            const {propertiesContent, refs} = transformProperties(!!schemaProperties ? schemaProperties : {}, swagger.data, {
+                typeMapping: openApiSchematicsConfig.typeMapping
+            });
             //   const importsContent = transformRefsToImport(refs.filter(refItem => refItem.importSymbol !== `I${parsed.name}`), `${openApiSchematicsConfig.path}` as string, `${parsed.path}/${dasherize(parsed.name)}`);
             const importRefs = removeImportDuplicates(refs.filter(refItem => refItem.importSymbol !== `I${parsed.name}`));
             itemSource = apply(interfaceTemplates, [

--- a/projects/swagger-schematics/types/templates/type-alias/__name@dasherize__.type.ts.template
+++ b/projects/swagger-schematics/types/templates/type-alias/__name@dasherize__.type.ts.template
@@ -1,0 +1,3 @@
+<%= transformRefsToImport(importRefs, optionsPath, sourcePath) %>
+
+export type T<%= classify(name) %> = <%= typeExpression %>;

--- a/projects/swagger-schematics/types/utils/params.ts
+++ b/projects/swagger-schematics/types/utils/params.ts
@@ -323,7 +323,11 @@ export function formatQueryParams(queryParams: IParsedParam<IQueryParam>[]): str
 
 /**
  * Formats body parameter for HTTP calls.
- * Returns body symbol for methods with body, "{}" for POST/PUT without body, "" otherwise.
+ * @param bodyParam - The parsed body parameter, or null if no body
+ * @param methodType - HTTP method (get, post, put, delete, etc.)
+ * @returns Body symbol for methods with body, "{}" for POST/PUT without body, 
+ *          or empty string for GET/DELETE/etc. without body.
+ *          Template authors: use truthy check (e.g., `if (bodyFormatted)`) to determine presence.
  */
 export function formatBody(bodyParam: IParsedParam<any> | null, methodType: string): string {
     if (bodyParam) return bodyParam.objectSymbol;

--- a/projects/swagger-schematics/types/utils/transform-type.ts
+++ b/projects/swagger-schematics/types/utils/transform-type.ts
@@ -199,6 +199,33 @@ function transformObjectSchema(schema: ISchemaObject, swagger: ISwaggerSchema, o
     return ['object'];
 }
 
+/**
+ * Known TypeScript primitive types that should never be resolved as schema references
+ */
+const PRIMITIVE_TYPE_NAMES = new Set([
+    'string', 'number', 'boolean', 'object', 'any', 'unknown', 'void', 'null', 'undefined',
+    'never', 'bigint', 'symbol'
+]);
+
+/**
+ * Check if a mapped value looks like a schema reference (not a primitive)
+ * Schema references typically:
+ * - Start with a capital letter (PascalCase)
+ * - Are not primitive type names
+ */
+function isLikelySchemaReference(value: string): boolean {
+    // Primitive types are never schema references
+    if (PRIMITIVE_TYPE_NAMES.has(value.toLowerCase())) {
+        return false;
+    }
+    
+    // Schema names typically start with a capital letter (PascalCase convention)
+    // If it starts with lowercase and isn't a primitive, it's likely a custom primitive alias
+    const startsWithCapital = /^[A-Z]/.test(value);
+    
+    return startsWithCapital;
+}
+
 export function parseRefToSymbol(property: IRef, swagger: ISwaggerSchema, options?: ITransformTypeOptions): TTypeWithImport {
     const { refPropertySchema, refPropertyKey } = getRefPropertyDefinition(property.$ref, swagger);
 
@@ -206,27 +233,30 @@ export function parseRefToSymbol(property: IRef, swagger: ISwaggerSchema, option
     if (options?.typeMapping && options.typeMapping[refPropertyKey]) {
         const mappedValue = options.typeMapping[refPropertyKey];
 
-        // Check if mapped value is another schema (not a primitive)
-        const { refPropertySchema: mappedSchema, refPropertyKey: mappedKey } =
-            getRefPropertyDefinition(`#/components/schemas/${mappedValue}`, swagger);
+        // Only attempt schema resolution if the mapped value looks like a schema reference
+        // This prevents primitive types from accidentally matching schema names
+        if (isLikelySchemaReference(mappedValue)) {
+            const { refPropertySchema: mappedSchema, refPropertyKey: mappedKey } =
+                getRefPropertyDefinition(`#/components/schemas/${mappedValue}`, swagger);
 
-        if (mappedSchema) {
-            // Use the mapped schema's type, but preserve nullable from the original schema
-            const originalIsNullable = refPropertySchema
-                ? Boolean((refPropertySchema as TSchemaWithType).nullable)
-                : false;
+            if (mappedSchema) {
+                // Use the mapped schema's type, but preserve nullable from the original schema
+                const originalIsNullable = refPropertySchema
+                    ? Boolean((refPropertySchema as TSchemaWithType).nullable)
+                    : false;
 
-            const symbol = transformRefProperty(mappedSchema, mappedKey);
-            const typeSymbol = originalIsNullable ? `${symbol} | null` : symbol;
+                const symbol = transformRefProperty(mappedSchema, mappedKey);
+                const typeSymbol = originalIsNullable ? `${symbol} | null` : symbol;
 
-            return [typeSymbol, {
-                type: isRefPropertyEnum(mappedSchema) ? 'enum' : 'interface',
-                importSymbol: symbol,
-                fileName: dasherize(mappedKey)
-            }];
+                return [typeSymbol, {
+                    type: isRefPropertyEnum(mappedSchema) ? 'enum' : 'interface',
+                    importSymbol: symbol,
+                    fileName: dasherize(mappedKey)
+                }];
+            }
         }
 
-        // Mapped to a primitive - preserve nullable from original if available
+        // Mapped to a primitive or the schema wasn't found - preserve nullable from original if available
         const originalIsNullable = refPropertySchema
             ? Boolean((refPropertySchema as TSchemaWithType).nullable)
             : false;
@@ -270,6 +300,12 @@ export function parseRefToSymbol(property: IRef, swagger: ISwaggerSchema, option
 function isPrimitiveWrapper(schema: TSchemaByType): boolean {
     // Must have a primitive type
     if (!('type' in schema)) {
+        return false;
+    }
+    
+    // Not a primitive wrapper if it uses composition (allOf, oneOf, anyOf, not)
+    // A schema can have both 'type' and composition, and composition takes precedence
+    if (isComposition(schema)) {
         return false;
     }
     


### PR DESCRIPTION
- Added support for composition schemas (`allOf`, `oneOf`, `anyOf`) generating TypeScript type aliases.
- Introduced `transformCompositionSchema()` helper for transforming composition schemas.
- Enhanced Angular base API generation to handle partial file existence correctly.
- Fixed issues with `typeMapping` and improved validation for primitive types.
- Updated tests for composition schema generation and interface/enum updates.
- Improved `getUrl` method in Angular base service for better URL handling.
- Removed unnecessary `MergeStrategy.AllowCreationConflict` from base API generation.
- Added new tests for `buildScopedApiMethodName` function and type mapping behavior.
- Updated changelog to reflect new features and fixes.