### PR TITLE
Update npm-publish workflow with registry URL

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -21,11 +21,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 18
+          registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies
         run: npm install
 
       - name: Run npm publish script
         run: npm run publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_SWAGGER_SCHEMATICS_SECRET }}


### PR DESCRIPTION
Add registry URL for npm and remove NODE_AUTH_TOKEN environment variable.