### PR TITLE
Release/1.0.0 beta.1

### DIFF
--- a/.agents/skills/changelog/SKILL.md
+++ b/.agents/skills/changelog/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: changelog
+description: Write or update CHANGELOG.md entries for the swagger-schematics project. Use this skill whenever the user mentions the changelog, wants to document what changed, says something shipped or was fixed, asks about release notes, or says things like "update changelog", "add changelog entry", "document changes", "write release notes", "what should I log", or "we just shipped X". Also trigger when the user asks to prepare for a release or bump a version — the changelog is always part of that workflow.
+---
+
+# Changelog Writing Skill
+
+Write and maintain CHANGELOG.md entries for `swagger-schematics` following the established format.
+
+## Workflow
+
+### Step 1: Gather what changed
+
+Before writing anything, ask the user what to include. Offer these options:
+
+1. **All changes in the current branch** — run `git log main..HEAD --oneline` (or `git log master..HEAD --oneline` if main doesn't exist) and read the relevant modified files to understand impact
+2. **Changes since last tag** — run `git log $(git describe --tags --abbrev=0)..HEAD --oneline`
+3. **Specific commits or files** — user tells you what to focus on
+4. **User describes the changes directly** — they'll just tell you what happened
+
+If the user already described the changes in their message, skip asking and proceed with what they gave you. If the context is ambiguous (e.g., "update the changelog"), ask.
+
+### Step 2: Draft the entry
+
+Read the top of `projects/swagger-schematics/CHANGELOG.md` to see the latest version and date. Use the format rules below.
+
+### Step 3: Generate PR message
+
+After writing the changelog entry, produce a pull request message (see **PR Message** section).
+
+## Format Rules
+
+**Version header:**
+```markdown
+## [1.0.0-alpha.XX] - YYYY-MM-DD
+```
+Always insert new versions at the **top** of the changelog (after the file header), above previous entries.
+
+**Section order** (only include sections that have content):
+1. `### ✨ Added`
+2. `### 🐛 Fixed`
+3. `### ♻️ Changed`
+4. `### 🗑️ Removed`
+5. `### 📦 Dependencies`
+
+Each section uses its emoji prefix — never plain `### Added` etc.
+
+**Breaking changes** go inside `### ♻️ Changed` with this marker:
+```markdown
+- ⚠️ **BREAKING**: description of the change
+```
+
+## Writing Style
+
+**Be specific and developer-focused.** Readers are devs consuming generated code or maintaining the schematic — they care about what changed in the API, templates, generated output, config options, and test coverage.
+
+**Good entry anatomy:**
+- Lead with the *what* (feature/fix name in bold or backtick if it's a symbol)
+- Follow with *why it matters* or *what the old behavior was*
+- Use sub-bullets for multiple related items under one feature
+
+**Examples from this project:**
+
+✅ Good:
+```markdown
+- **Composition schema support** - `allOf`, `oneOf`, and `anyOf` schemas now generate TypeScript type aliases:
+  - `allOf` → intersection type (`TMyType = TypeA & TypeB`)
+  - `oneOf` / `anyOf` → union type (`TMyType = TypeA | TypeB`)
+```
+
+```markdown
+- `scopeEndpointsWithTags` option for RTK to prefix endpoint names with tag (e.g., `claimGetById`)
+```
+
+```markdown
+- Angular base API generation now correctly handles partial file existence:
+  - Previously only skipped generation if BOTH files existed
+  - Now generates only the missing file(s) when one exists and the other doesn't
+```
+
+❌ Avoid:
+```markdown
+- Fixed a bug
+- Added new feature
+- Updated code
+```
+
+## Gathering Content
+
+Before writing, check what actually changed:
+1. Look at recent git commits: `git log --oneline -20`
+2. Read modified files to understand the impact
+3. Check test changes — new tests often reveal what was fixed/added
+4. Ask the user if intent is unclear from the diff
+
+Group related changes under one bullet with sub-bullets rather than listing them separately.
+
+## Version Numbering
+
+This project follows semver with pre-release labels: `1.0.0-alpha.XX`, `1.0.0-beta.XX`, `1.0.0-rc.XX`, or plain `1.0.0`. The user manages version bumping — do not change version numbers unless explicitly asked.
+
+## Dependency Updates
+
+For `### 📦 Dependencies`, list each package with old → new version:
+```markdown
+- Updated @angular-devkit packages to 20.3.14
+- Updated axios to 1.13.2
+```
+
+If multiple packages belong to the same suite (e.g., `@angular-devkit/*`), group them on one line.
+
+## PR Message
+
+After writing the changelog entry, generate a pull request message in this format:
+
+```
+<Title>
+
+<Description>
+```
+
+- **Title**: one brief line summarizing the most important change (e.g., `feat: RTK URL controller segment fix` or `fix: Angular base API partial file existence`)
+- **Description**: a short paragraph or bullet list of the important changes — drawn from what you just wrote in the changelog, but written for a reviewer rather than a user. Focus on *what* changed and *why*, not the formatting details.

--- a/projects/swagger-schematics/CHANGELOG.md
+++ b/projects/swagger-schematics/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-beta.1] - 2026-07-20
+
+### 🐛 Fixed
+- **String enum generation** - enum members now get quoted string values:
+  - Previously `{ enum: ["Email", "PhoneCall"], type: "string" }` generated invalid TypeScript (`Email = Email`); now generates `Email = 'Email'`
+  - Works with `x-enum-varnames` when the member name differs from the value (`PhoneCall = 'phone-call'`)
+  - Single quotes inside values are escaped; integer enum values remain unquoted
+- **RTK endpoint URLs now include the controller segment** - `url` was previously generated without the controller path (e.g. `` url: `/${id}` ``); now the dasherized controller name is prefixed (e.g. `` url: `/claim/${id}` ``)
+- **`ApiBaseService.getUrl` strips a trailing `/api` segment from `apiBaseUrl`** (case-insensitive, with or without trailing slash) so a configured base URL like `https://host/api` no longer produces `/api/api/...` in request URLs
+
+### ✨ Added
+- Jest configuration in `package.json` - the test suite now runs out of the box (`npm test`); previously the jest config was not committed
+- Tests for string enum generation: quoted values, `x-enum-varnames` with string values, and a guard that integer enums stay unquoted
+- Tests for `ApiBaseService.getUrl` covering all URL variants - the generated service is compiled and executed:
+  - Relative URLs when `apiBaseUrl` is empty, nested segments, repeated-slash normalization
+  - Base URLs with/without trailing slash, ending in `/api` (any case), and with extra path segments
+  - A guard that the generated file compiles without TypeScript diagnostics
+- Changelog writing skill (`.agents/skills/changelog/SKILL.md`) to guide CHANGELOG.md updates
+
+### ♻️ Changed
+- npm publish workflow now publishes with provenance and explicit public access, uses the npm registry URL, and sets `NODE_AUTH_TOKEN` for the publish step
+
+
 ## [1.0.0-alpha.31] - 2026-03-05
 
 ### ✨ Added

--- a/projects/swagger-schematics/CHANGELOG.md
+++ b/projects/swagger-schematics/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.31] - 2026-03-05
+
+### ✨ Added
+- **Nullable query parameter support** in generated API methods (Angular and RTK):
+  - Query params with `nullable: true` or `default: null` now get `| null` in their TypeScript type and are marked optional (`?`) in method signatures and destructured parameter objects
+  - When an operation has nullable query params, the generated `params` object is wrapped in `omitBy({ ... }, isNil)` so `null`/`undefined` values are stripped before the request is sent
+  - `import { omitBy, isNil } from 'lodash-es'` is added to generated Angular services and RTK API files only when at least one endpoint needs it
+- `hasNullableQueryParams` property on `IParsedApiItem` for custom templates
+- Tests for nullable query params: Angular/RTK integration tests, `transformType` unit tests, and a `GET_WITH_NULLABLE_QUERY_PARAMS` fixture
+
+### ♻️ Changed
+- `isNullable()` now also treats schemas with `default: null` as nullable (previously only `nullable: true`), including when resolved through `$ref`
+- `formatQueryParams()` accepts a `hasNullable` flag to control `omitBy` wrapping
+
+
 ## [1.0.0-alpha.30] - 2026-01-27
 
 ### ✨ Added

--- a/projects/swagger-schematics/__tests__/__fixtures__/rtk-options.fixture.json
+++ b/projects/swagger-schematics/__tests__/__fixtures__/rtk-options.fixture.json
@@ -1,5 +1,6 @@
 {
   "swaggerSchemaUrl": "https://api.example.com/swagger/v1/swagger.json",
   "path": "/test-output",
-  "framework": "react-rtk"
+  "framework": "react-rtk",
+  "scopeEndpointsWithTags": true
 }

--- a/projects/swagger-schematics/__tests__/__fixtures__/swagger/schemas/enums.fixtures.ts
+++ b/projects/swagger-schematics/__tests__/__fixtures__/swagger/schemas/enums.fixtures.ts
@@ -20,6 +20,11 @@ export const NULLABLE_OF_DISTRIBUTION_TYPE_ENUM_SCHEMA: TSchemaByType = createEn
   nullable: true
 });
 
+export const DELIVERY_CHANNEL_ENUM_SCHEMA: TSchemaByType = createEnumSchema(['email', 'phone-call'], {
+  type: 'string',
+  varnames: ['Email', 'PhoneCall']
+});
+
 // ============================================================================
 // All Enums (Combined Export)
 // ============================================================================
@@ -28,5 +33,6 @@ export const ENUM_SCHEMAS: Record<string, TSchemaByType> = {
   ClaimStatuses: CLAIM_STATUSES_ENUM_SCHEMA,
   ClaimType: CLAIM_TYPE_ENUM_SCHEMA,
   DistributionType: DISTRIBUTION_TYPE_ENUM_SCHEMA,
-  NullableOfDistributionType: NULLABLE_OF_DISTRIBUTION_TYPE_ENUM_SCHEMA
+  NullableOfDistributionType: NULLABLE_OF_DISTRIBUTION_TYPE_ENUM_SCHEMA,
+  DeliveryChannel: DELIVERY_CHANNEL_ENUM_SCHEMA
 };

--- a/projects/swagger-schematics/__tests__/integration/__snapshots__/angular-schematics.spec.ts.snap
+++ b/projects/swagger-schematics/__tests__/integration/__snapshots__/angular-schematics.spec.ts.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Schematics Integration API Service Generation should generate full API service 1`] = `
-"import { Injectable } from \\"@angular/core\\";
-import { ApiBaseService } from \\"./_api-base.service\\";
-import { Observable } from \\"rxjs\\";
+"import { Injectable } from "@angular/core";
+import { ApiBaseService } from "./_api-base.service";
+import { Observable } from "rxjs";
 
 import { omitBy, isNil } from 'lodash-es';
 
@@ -182,6 +182,7 @@ exports[`Schematics Integration File Generation should generate expected files 1
   "/test-output/enums/claim-type.enum.ts",
   "/test-output/enums/distribution-type.enum.ts",
   "/test-output/enums/nullable-of-distribution-type.enum.ts",
+  "/test-output/enums/delivery-channel.enum.ts",
 ]
 `;
 

--- a/projects/swagger-schematics/__tests__/integration/__snapshots__/rtk-schematics.spec.ts.snap
+++ b/projects/swagger-schematics/__tests__/integration/__snapshots__/rtk-schematics.spec.ts.snap
@@ -20,6 +20,7 @@ exports[`RTK Query Schematics Integration File Generation should generate expect
   "/test-output/enums/claim-type.enum.ts",
   "/test-output/enums/distribution-type.enum.ts",
   "/test-output/enums/nullable-of-distribution-type.enum.ts",
+  "/test-output/enums/delivery-channel.enum.ts",
   "/th-common/store/api-base.ts",
 ]
 `;

--- a/projects/swagger-schematics/__tests__/integration/__snapshots__/rtk-schematics.spec.ts.snap
+++ b/projects/swagger-schematics/__tests__/integration/__snapshots__/rtk-schematics.spec.ts.snap
@@ -39,116 +39,116 @@ import { TClaimStatuses } from './enums/claim-statuses.enum';
 export const claimApi = baseApi.injectEndpoints({
   overrideExisting: false,
   endpoints: (builder) => ({
-    getById: builder.query<IClaimDetailDTO, { id: number }>({
+    claimGetById: builder.query<IClaimDetailDTO, { id: number }>({
       query: ({ id }) => ({
-        url: \`/\${id}\`,
+        url: \`/claim/\${id}\`,
         method: 'GET',
       }),
     }),
-    updateClaimById: builder.mutation<IClaimDetailDTO, { id: number; body: IClaimDetailDTO }>({
+    claimUpdateClaimById: builder.mutation<IClaimDetailDTO, { id: number; body: IClaimDetailDTO }>({
       query: ({ id, body }) => ({
-        url: \`/\${id}\`,
+        url: \`/claim/\${id}\`,
         method: 'PUT',
         body,
       }),
     }),
-    getServiceActionsByClaimId: builder.query<IClaimDetailDTO, { claimId: number }>({
+    claimGetServiceActionsByClaimId: builder.query<IClaimDetailDTO, { claimId: number }>({
       query: ({ claimId }) => ({
-        url: \`/\${claimId}/serviceActions\`,
+        url: \`/claim/\${claimId}/serviceActions\`,
         method: 'GET',
       }),
     }),
-    createClaim: builder.mutation<void, { width: number; height: number; body: object }>({
+    claimCreateClaim: builder.mutation<void, { width: number; height: number; body: object }>({
       query: ({ width, height, body }) => ({
-        url: '/',
+        url: '/claim',
         method: 'POST',
         body,
         params: { width, height },
       }),
     }),
-    createClaimByIdNote: builder.mutation<IClaimNoteViewDTO, { id: number; body: ICreateNoteDTO }>({
+    claimCreateClaimByIdNote: builder.mutation<IClaimNoteViewDTO, { id: number; body: ICreateNoteDTO }>({
       query: ({ id, body }) => ({
-        url: \`/\${id}/note\`,
+        url: \`/claim/\${id}/note\`,
         method: 'POST',
         body,
       }),
     }),
-    updateClaimStatus: builder.mutation<void, { body: number }>({
+    claimUpdateClaimStatus: builder.mutation<void, { body: number }>({
       query: ({ body }) => ({
-        url: '/status',
+        url: '/claim/status',
         method: 'PUT',
         body,
       }),
     }),
-    postClaimAll: builder.mutation<IClaimDetailDTO, { body: ICompanySearchDTO }>({
+    claimPostClaimAll: builder.mutation<IClaimDetailDTO, { body: ICompanySearchDTO }>({
       query: ({ body }) => ({
-        url: '/all',
+        url: '/claim/all',
         method: 'POST',
         body,
       }),
     }),
-    postClaimIds: builder.mutation<number[], { body: ICompanySearchDTO }>({
+    claimPostClaimIds: builder.mutation<number[], { body: ICompanySearchDTO }>({
       query: ({ body }) => ({
-        url: '/ids',
+        url: '/claim/ids',
         method: 'POST',
         body,
       }),
     }),
-    updateClaimByIdReactivate: builder.mutation<void, { id: number }>({
+    claimUpdateClaimByIdReactivate: builder.mutation<void, { id: number }>({
       query: ({ id }) => ({
-        url: \`/\${id}/reactivate\`,
+        url: \`/claim/\${id}/reactivate\`,
         method: 'PUT',
       }),
     }),
-    deleteClaimDeletemany: builder.mutation<boolean, { body: number[] }>({
+    claimDeleteClaimDeletemany: builder.mutation<boolean, { body: number[] }>({
       query: ({ body }) => ({
-        url: '/deletemany',
+        url: '/claim/deletemany',
         method: 'DELETE',
         body,
       }),
     }),
-    getClaimServiceactions: builder.query<number[], { serviceActionId: number }>({
+    claimGetClaimServiceactions: builder.query<number[], { serviceActionId: number }>({
       query: ({ serviceActionId }) => ({
-        url: '/serviceactions',
+        url: '/claim/serviceactions',
         method: 'GET',
       }),
     }),
-    getClaimServiceactionsByServiceActionId: builder.query<number[], { serviceActionId: number }>({
+    claimGetClaimServiceactionsByServiceActionId: builder.query<number[], { serviceActionId: number }>({
       query: ({ serviceActionId }) => ({
-        url: \`/serviceactions/\${serviceActionId}\`,
+        url: \`/claim/serviceactions/\${serviceActionId}\`,
         method: 'GET',
       }),
     }),
-    getClaimBystatus: builder.query<IClaimDetailDTO[], { id: string; status: TClaimStatuses }>({
+    claimGetClaimBystatus: builder.query<IClaimDetailDTO[], { id: string; status: TClaimStatuses }>({
       query: ({ id, status }) => ({
-        url: '/bystatus',
+        url: '/claim/bystatus',
         method: 'GET',
         params: { id, status },
       }),
     }),
-    updateClaimNoteById: builder.mutation<void, { body: ICreateNoteDTO }>({
+    claimUpdateClaimNoteById: builder.mutation<void, { body: ICreateNoteDTO }>({
       query: ({ body }) => ({
-        url: \`/note/\${body.id}\`,
+        url: \`/claim/note/\${body.id}\`,
         method: 'PUT',
         body,
       }),
     }),
-    deleteClaimSingleById: builder.mutation<void, { id: number }>({
+    claimDeleteClaimSingleById: builder.mutation<void, { id: number }>({
       query: ({ id }) => ({
-        url: \`/single/\${id}\`,
+        url: \`/claim/single/\${id}\`,
         method: 'DELETE',
       }),
     }),
-    deleteClaimByFilter: builder.mutation<boolean, { status: string; force: boolean }>({
+    claimDeleteClaimByFilter: builder.mutation<boolean, { status: string; force: boolean }>({
       query: ({ status, force }) => ({
-        url: '/by-filter',
+        url: '/claim/by-filter',
         method: 'DELETE',
         params: { status, force },
       }),
     }),
-    getClaimSearch: builder.query<IClaimDetailDTO[], { name: string; status: string | null; priority: number | null }>({
+    claimGetClaimSearch: builder.query<IClaimDetailDTO[], { name: string; status: string | null; priority: number | null }>({
       query: ({ name, status, priority }) => ({
-        url: '/search',
+        url: '/claim/search',
         method: 'GET',
         params: omitBy({ name, status, priority }, isNil),
       }),

--- a/projects/swagger-schematics/__tests__/integration/__snapshots__/types-schematics.spec.ts.snap
+++ b/projects/swagger-schematics/__tests__/integration/__snapshots__/types-schematics.spec.ts.snap
@@ -18,6 +18,22 @@ exports[`Types Schematics Integration Enum Generation should generate ClaimType 
 "
 `;
 
+exports[`Types Schematics Integration Enum Generation should generate string enum with quoted string values 1`] = `
+"export enum TDistributionType {
+  TypeA = 'TypeA',
+  TypeB = 'TypeB'
+}
+"
+`;
+
+exports[`Types Schematics Integration Enum Generation should generate string enum with x-enum-varnames and quoted string values 1`] = `
+"export enum TDeliveryChannel {
+  Email = 'email',
+  PhoneCall = 'phone-call'
+}
+"
+`;
+
 exports[`Types Schematics Integration File Generation should generate expected type files 1`] = `
 [
   "/.editorconfig",
@@ -37,6 +53,7 @@ exports[`Types Schematics Integration File Generation should generate expected t
   "/test-output/enums/claim-type.enum.ts",
   "/test-output/enums/distribution-type.enum.ts",
   "/test-output/enums/nullable-of-distribution-type.enum.ts",
+  "/test-output/enums/delivery-channel.enum.ts",
 ]
 `;
 

--- a/projects/swagger-schematics/__tests__/integration/api-base-service.spec.ts
+++ b/projects/swagger-schematics/__tests__/integration/api-base-service.spec.ts
@@ -1,0 +1,131 @@
+import * as ts from 'typescript';
+import { UnitTestTree } from '@angular-devkit/schematics/testing';
+import {
+  setupSwaggerMock,
+  resetAxiosMocks,
+  runApiSchematic,
+  createTestTree,
+  ANGULAR_SCHEMATIC_OPTIONS
+} from '../helpers/setup';
+import { SWAGGER_SCHEMA } from '../__fixtures__/swagger/full-schema.fixture';
+
+const API_BASE_URL_TOKEN = Symbol('API_BASE_URL');
+
+/**
+ * Compiles the generated _api-base.service.ts to CommonJS and evaluates it with
+ * stubbed Angular modules so the real getUrl implementation can be executed.
+ */
+function loadApiBaseServiceClass(source: string, apiBaseUrl: string): any {
+  const js = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020
+    }
+  }).outputText;
+
+  const moduleStubs: Record<string, any> = {
+    '@angular/common/http': { HttpClient: class HttpClient {} },
+    '@angular/core': {
+      inject: (token: any) => (token === API_BASE_URL_TOKEN ? apiBaseUrl : {})
+    },
+    './_api-base-url.token': { API_BASE_URL: API_BASE_URL_TOKEN }
+  };
+
+  const exports: any = {};
+  new Function('require', 'exports', js)((id: string) => moduleStubs[id] ?? {}, exports);
+  return exports.ApiBaseService;
+}
+
+describe('ApiBaseService getUrl', () => {
+  let generatedSource: string;
+
+  const createService = (apiBaseUrl: string, endpoint: string = 'Claim') => {
+    const ApiBaseService = loadApiBaseServiceClass(generatedSource, apiBaseUrl);
+    class TestApiService extends ApiBaseService {
+      readonly endpoint = endpoint;
+    }
+    return new TestApiService() as unknown as { getUrl(url?: string): string };
+  };
+
+  beforeAll(async () => {
+    setupSwaggerMock(ANGULAR_SCHEMATIC_OPTIONS.swaggerSchemaUrl, SWAGGER_SCHEMA);
+    const tree: UnitTestTree = await runApiSchematic(ANGULAR_SCHEMATIC_OPTIONS, createTestTree());
+    generatedSource = tree.readContent(`${ANGULAR_SCHEMATIC_OPTIONS.path}/_api-base.service.ts`);
+  });
+
+  afterAll(() => {
+    resetAxiosMocks();
+  });
+
+  it('should generate compilable TypeScript without diagnostics', () => {
+    const output = ts.transpileModule(generatedSource, {
+      compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020 },
+      reportDiagnostics: true
+    });
+    expect(output.diagnostics).toEqual([]);
+  });
+
+  describe('without apiBaseUrl (relative URLs)', () => {
+    it('should build a relative URL with no url argument', () => {
+      expect(createService('').getUrl()).toBe('/api/Claim');
+    });
+
+    it('should build a relative URL with a single segment', () => {
+      expect(createService('').getUrl('detail')).toBe('/api/Claim/detail');
+    });
+
+    it('should build a relative URL with nested segments', () => {
+      expect(createService('').getUrl('5/notes')).toBe('/api/Claim/5/notes');
+    });
+
+    it('should normalize repeated slashes in the url argument', () => {
+      expect(createService('').getUrl('//5//notes')).toBe('/api/Claim/5/notes');
+    });
+  });
+
+  describe('with apiBaseUrl', () => {
+    it('should prepend a plain host base URL', () => {
+      expect(createService('https://example.com').getUrl('5')).toBe('https://example.com/api/Claim/5');
+    });
+
+    it('should handle a base URL with a trailing slash', () => {
+      expect(createService('https://example.com/').getUrl('5')).toBe('https://example.com/api/Claim/5');
+    });
+
+    it('should not duplicate the api segment when the base URL ends with /api', () => {
+      expect(createService('https://example.com/api').getUrl('5')).toBe('https://example.com/api/Claim/5');
+    });
+
+    it('should not duplicate the api segment when the base URL ends with /api/', () => {
+      expect(createService('https://example.com/api/').getUrl('5')).toBe('https://example.com/api/Claim/5');
+    });
+
+    it('should strip a trailing /api segment case-insensitively', () => {
+      expect(createService('https://example.com/API').getUrl('5')).toBe('https://example.com/api/Claim/5');
+    });
+
+    it('should preserve path segments in the base URL', () => {
+      expect(createService('https://example.com/v1/internal').getUrl('5')).toBe(
+        'https://example.com/v1/internal/api/Claim/5'
+      );
+    });
+
+    it('should preserve path segments when the base URL also ends with /api', () => {
+      expect(createService('https://example.com/v1/api').getUrl('5')).toBe('https://example.com/v1/api/Claim/5');
+    });
+
+    it('should build the base URL variant with no url argument', () => {
+      expect(createService('https://example.com').getUrl()).toBe('https://example.com/api/Claim');
+    });
+  });
+
+  describe('endpoint variants', () => {
+    it('should use the subclass endpoint in the URL', () => {
+      expect(createService('', 'ServiceAction').getUrl('7')).toBe('/api/ServiceAction/7');
+    });
+
+    it('should skip an empty endpoint without producing double slashes', () => {
+      expect(createService('', '').getUrl('7')).toBe('/api/7');
+    });
+  });
+});

--- a/projects/swagger-schematics/__tests__/integration/rtk-schematics.spec.ts
+++ b/projects/swagger-schematics/__tests__/integration/rtk-schematics.spec.ts
@@ -92,26 +92,26 @@ describe('RTK Query Schematics Integration', () => {
 
     describe('Query Endpoints', () => {
       it('should generate GET endpoint as query', () => {
-        expect(apiSliceContent).toMatch(/getById:\s*builder\.query/);
+        expect(apiSliceContent).toMatch(/claimGetById:\s*builder\.query/);
       });
 
       it('should generate query with path parameter', () => {
-        expect(apiSliceContent).toContain("url: `/${id}`");
+        expect(apiSliceContent).toContain("url: `/claim/${id}`");
         expect(apiSliceContent).toContain("method: 'GET'");
       });
     });
 
     describe('Mutation Endpoints', () => {
       it('should generate POST endpoint as mutation', () => {
-        expect(apiSliceContent).toMatch(/createClaimByIdNote:\s*builder\.mutation/);
+        expect(apiSliceContent).toMatch(/claimCreateClaimByIdNote:\s*builder\.mutation/);
       });
 
       it('should generate PUT endpoint as mutation', () => {
-        expect(apiSliceContent).toMatch(/updateClaimById:\s*builder\.mutation/);
+        expect(apiSliceContent).toMatch(/claimUpdateClaimById:\s*builder\.mutation/);
       });
 
       it('should generate DELETE endpoint as mutation', () => {
-        expect(apiSliceContent).toMatch(/deleteClaimDeletemany:\s*builder\.mutation/);
+        expect(apiSliceContent).toMatch(/claimDeleteClaimDeletemany:\s*builder\.mutation/);
       });
 
       it('should include body in mutation', () => {

--- a/projects/swagger-schematics/__tests__/integration/types-schematics.spec.ts
+++ b/projects/swagger-schematics/__tests__/integration/types-schematics.spec.ts
@@ -49,6 +49,33 @@ describe('Types Schematics Integration', () => {
       const content = tree.readContent(`${ANGULAR_SCHEMATIC_OPTIONS.path}/enums/claim-type.enum.ts`);
       expect(content).toMatchSnapshot();
     });
+
+    it('should keep integer enum values unquoted', () => {
+      const content = tree.readContent(`${ANGULAR_SCHEMATIC_OPTIONS.path}/enums/claim-type.enum.ts`);
+
+      expect(content).toContain('MS = 1');
+      expect(content).toContain('PP = 2');
+      expect(content).not.toContain("'1'");
+      expect(content).not.toContain("'2'");
+    });
+
+    it('should generate string enum with quoted string values', () => {
+      const content = tree.readContent(`${ANGULAR_SCHEMATIC_OPTIONS.path}/enums/distribution-type.enum.ts`);
+
+      expect(content).toContain('export enum TDistributionType');
+      expect(content).toContain("TypeA = 'TypeA'");
+      expect(content).toContain("TypeB = 'TypeB'");
+      expect(content).toMatchSnapshot();
+    });
+
+    it('should generate string enum with x-enum-varnames and quoted string values', () => {
+      const content = tree.readContent(`${ANGULAR_SCHEMATIC_OPTIONS.path}/enums/delivery-channel.enum.ts`);
+
+      expect(content).toContain('export enum TDeliveryChannel');
+      expect(content).toContain("Email = 'email'");
+      expect(content).toContain("PhoneCall = 'phone-call'");
+      expect(content).toMatchSnapshot();
+    });
   });
 
   describe('Interface Generation', () => {
@@ -148,7 +175,7 @@ describe('Types Schematics Integration', () => {
   describe('Composition Schema Generation', () => {
     it('should generate type alias for allOf schemas', () => {
       const content = tree.readContent(`${ANGULAR_SCHEMATIC_OPTIONS.path}/interfaces/full-claim-dto.type.ts`);
-      
+
       // Should be a type alias with T prefix, not interface with I prefix
       expect(content).toContain('export type TFullClaimDTO =');
       // Should be intersection type with &
@@ -160,7 +187,7 @@ describe('Types Schematics Integration', () => {
 
     it('should generate type alias for oneOf schemas', () => {
       const content = tree.readContent(`${ANGULAR_SCHEMATIC_OPTIONS.path}/interfaces/notification.type.ts`);
-      
+
       // Should be a type alias with T prefix
       expect(content).toContain('export type TNotification =');
       expect(content).toContain('|');
@@ -171,7 +198,7 @@ describe('Types Schematics Integration', () => {
 
     it('should generate type alias for anyOf schemas', () => {
       const content = tree.readContent(`${ANGULAR_SCHEMATIC_OPTIONS.path}/interfaces/search-result.type.ts`);
-      
+
       // Should be a type alias with T prefix
       expect(content).toContain('export type TSearchResult =');
       expect(content).toContain('|');
@@ -190,34 +217,34 @@ describe('Types Schematics Integration', () => {
     beforeAll(async () => {
       resetAxiosMocks();
       setupSwaggerMock(ANGULAR_SCHEMATIC_OPTIONS.swaggerSchemaUrl, SWAGGER_SCHEMA);
-      
+
       const optionsWithTypeMapping = {
         ...ANGULAR_SCHEMATIC_OPTIONS,
         typeMapping: {
           'NullableOfDistributionType': 'DistributionType'
         }
       };
-      
+
       typeMappingTree = await runTypesSchematic(optionsWithTypeMapping, createTestTree());
     });
 
     it('should map NullableOfDistributionType to DistributionType with | null in interface', () => {
       const content = typeMappingTree.readContent(`${ANGULAR_SCHEMATIC_OPTIONS.path}/interfaces/type-mapping-test-dto.interface.ts`);
-      
+
       // Should use DistributionType import, not NullableOfDistributionType
       expect(content).toContain("import { TDistributionType }");
       expect(content).toContain("from '../enums/distribution-type.enum'");
-      
+
       // Should NOT import from nullable-of-distribution-type
       expect(content).not.toContain('nullable-of-distribution-type');
-      
+
       // Should have | null for the nullable type
       expect(content).toContain('TDistributionType | null');
     });
 
     it('should use original NullableOfDistributionType import when typeMapping is not set', () => {
       const content = tree.readContent(`${ANGULAR_SCHEMATIC_OPTIONS.path}/interfaces/type-mapping-test-dto.interface.ts`);
-      
+
       // Without typeMapping, should use the original NullableOfDistributionType
       expect(content).toContain("import { TNullableOfDistributionType }");
       expect(content).toContain("from '../enums/nullable-of-distribution-type.enum'");

--- a/projects/swagger-schematics/api/templates/angular/base-api/_api-base.service.ts.template
+++ b/projects/swagger-schematics/api/templates/angular/base-api/_api-base.service.ts.template
@@ -14,8 +14,11 @@ export abstract class ApiBaseService {
       .join('/')
       .replace(/\/+/g, '/');
 
-    return this.apiBaseUrl
-      ? `${this.apiBaseUrl.replace(/\/$/, '')}/${path}`
-      : `/${path}`;
+    if (!this.apiBaseUrl) {
+      return `/${path}`;
+    }
+
+    const baseUrl = this.apiBaseUrl.replace(/\/$/, '').replace(/\/api$/i, '');
+    return `${baseUrl}/${path}`;
   }
 }

--- a/projects/swagger-schematics/api/templates/react-rtk/api/__name@dasherize__.api.ts.template
+++ b/projects/swagger-schematics/api/templates/react-rtk/api/__name@dasherize__.api.ts.template
@@ -16,9 +16,12 @@ export const <%= apiExportName %> = baseApi.injectEndpoints({
   let builderMethod = item.isQuery ? 'builder.query' : 'builder.mutation';
   let endpointName = scopeEndpointsWithTags ? item.scopedApiMethodName : item.apiMethodName;
   let queryParamsList = item.queryParams.map(p => p.objectSymbol);
+  let rawUrl = item.apiUrl ? (dasherize(name) + '/' + item.apiUrl) : dasherize(name);
+  let hasInterpolation = rawUrl.includes('${');
+  let fullUrl = hasInterpolation ? '`/' + rawUrl + '`' : "'/" + rawUrl + "'";
 %>    <%= endpointName %>: <%= builderMethod %><<%= item.responseTypeSymbol %>, <%= item.apiMethodRequestType %>>({
       query: (<%= args %>) => ({
-        url: <%= item.apiUrlFormatted %>,
+        url: <%= fullUrl %>,
         method: '<%= item.httpMethod %>',
 <% if (item.bodyParam) { %>        <%= item.bodyParam.objectSymbol %>,
 <% } if (item.queryParams.length > 0 && item.hasNullableQueryParams) { %>        params: omitBy({ <%= queryParamsList.join(', ') %> }, isNil),

--- a/projects/swagger-schematics/package.json
+++ b/projects/swagger-schematics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-schematics",
-  "version": "1.0.0-alpha.31",
+  "version": "1.0.0-beta.1",
   "description": "Schematics types and API generator via Swagger scheme",
   "scripts": {
     "prebuild": "dtsgen --out schema.d.ts **/schema.json",

--- a/projects/swagger-schematics/package.json
+++ b/projects/swagger-schematics/package.json
@@ -13,6 +13,28 @@
     "test:update-snapshots": "jest --updateSnapshot"
   },
   "schematics": "./collection.json",
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node",
+    "roots": [
+      "<rootDir>/__tests__"
+    ],
+    "testMatch": [
+      "**/*.spec.ts"
+    ],
+    "transform": {
+      "^.+\\.ts$": [
+        "ts-jest",
+        {
+          "tsconfig": "tsconfig.spec.json"
+        }
+      ]
+    },
+    "moduleNameMapper": {
+      "^@fixtures/(.*)$": "<rootDir>/__tests__/__fixtures__/$1",
+      "^@helpers/(.*)$": "<rootDir>/__tests__/helpers/$1"
+    }
+  },
   "keywords": [
     "schematics",
     "angular",

--- a/projects/swagger-schematics/types/utils/enum.ts
+++ b/projects/swagger-schematics/types/utils/enum.ts
@@ -1,4 +1,6 @@
-export function enumLine(enumValue: [string, number], index: number, enums: [string, number][], indentSize: string) {
+export function enumLine(enumValue: [string, number | string], index: number, enums: [string, number | string][], indentSize: string) {
     const indentString = ' '.repeat(parseInt(indentSize, 10));
-    return `${indentString}${enumValue.join(' = ')}${index !== enums.length - 1 ? ',\n' : ''}`
+    const [name, value] = enumValue;
+    const formattedValue = typeof value === 'string' ? `'${value.replace(/'/g, "\\'")}'` : value;
+    return `${indentString}${name} = ${formattedValue}${index !== enums.length - 1 ? ',\n' : ''}`
 }


### PR DESCRIPTION
## [1.0.0-beta.1] - 2026-07-20

### 🐛 Fixed
- **String enum generation** - enum members now get quoted string values:
  - Previously `{ enum: ["Email", "PhoneCall"], type: "string" }` generated invalid TypeScript (`Email = Email`); now generates `Email = 'Email'`
  - Works with `x-enum-varnames` when the member name differs from the value (`PhoneCall = 'phone-call'`)
  - Single quotes inside values are escaped; integer enum values remain unquoted
- **RTK endpoint URLs now include the controller segment** - `url` was previously generated without the controller path (e.g. `` url: `/${id}` ``); now the dasherized controller name is prefixed (e.g. `` url: `/claim/${id}` ``)
- **`ApiBaseService.getUrl` strips a trailing `/api` segment from `apiBaseUrl`** (case-insensitive, with or without trailing slash) so a configured base URL like `https://host/api` no longer produces `/api/api/...` in request URLs

### ✨ Added
- Jest configuration in `package.json` - the test suite now runs out of the box (`npm test`); previously the jest config was not committed
- Tests for string enum generation: quoted values, `x-enum-varnames` with string values, and a guard that integer enums stay unquoted
- Tests for `ApiBaseService.getUrl` covering all URL variants - the generated service is compiled and executed:
  - Relative URLs when `apiBaseUrl` is empty, nested segments, repeated-slash normalization
  - Base URLs with/without trailing slash, ending in `/api` (any case), and with extra path segments
  - A guard that the generated file compiles without TypeScript diagnostics
- Changelog writing skill (`.agents/skills/changelog/SKILL.md`) to guide CHANGELOG.md updates

### ♻️ Changed
- npm publish workflow now publishes with provenance and explicit public access, uses the npm registry URL, and sets `NODE_AUTH_TOKEN` for the publish step
