### PR TITLE
fix: 1.0.1 - full error logging for silent CI failures

### DIFF
--- a/projects/swagger-schematics/CHANGELOG.md
+++ b/projects/swagger-schematics/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.1] - 2026-07-23
+
+### 🐛 Fixed
+- **Failures are no longer silent** - both schematics now print a full error report to the console (message and stack for the whole `cause` chain) before failing. Previously a crash in CI (e.g. Azure Pipelines) could abort generation with no output at all
+- **Network errors now show the real reason** - Node's `fetch` reports failures as a bare `fetch failed`, hiding the underlying cause (DNS resolution, proxy, TLS) in `error.cause`; the schema download now surfaces the whole chain, e.g. `Failed to fetch swagger schema from '<url>': fetch failed -> getaddrinfo ENOTFOUND host`
+- Invalid JSON in `openapi-schematics.json` or in the downloaded schema now fails with a clear message naming the file/URL instead of a bare `SyntaxError`
+
+### ✨ Added
+- A `Fetching swagger schema from '<url>'` console line at the start of generation, so CI logs show how far generation got
+
+
 ## [1.0.0] - 2026-07-22
 
 ### ✨ Added

--- a/projects/swagger-schematics/__tests__/integration/error-logging.spec.ts
+++ b/projects/swagger-schematics/__tests__/integration/error-logging.spec.ts
@@ -1,0 +1,18 @@
+import '../helpers/matchers';
+import { runTypesSchematic, resetFetchMocks, ANGULAR_SCHEMATIC_OPTIONS } from '../helpers/setup';
+
+describe('schematic error logging', () => {
+  it('should print a full error report to the console when the schema fetch fails', async () => {
+    // No mock registered for the URL -> the fetch mock answers 404
+    resetFetchMocks();
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    await expect(runTypesSchematic(ANGULAR_SCHEMATIC_OPTIONS)).rejects.toThrow('404');
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("'types' schematic failed"));
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining(ANGULAR_SCHEMATIC_OPTIONS.swaggerSchemaUrl)
+    );
+    consoleSpy.mockRestore();
+  });
+});

--- a/projects/swagger-schematics/__tests__/unit/error-logging.spec.ts
+++ b/projects/swagger-schematics/__tests__/unit/error-logging.spec.ts
@@ -1,0 +1,102 @@
+import { describeErrorChain, formatSchematicError, logSchematicError, wrapRuleWithErrorLogging } from '../../helpers/error-logging.helper';
+import { fetchSwaggerSchema } from '../../helpers/swagger-schema.helper';
+
+describe('error logging', () => {
+  const chainedError = () => {
+    const root = new Error('getaddrinfo ENOTFOUND swagger.internal.host');
+    const fetchError = new TypeError('fetch failed');
+    (fetchError as TypeError & { cause?: unknown }).cause = root;
+    return fetchError;
+  };
+
+  describe('describeErrorChain', () => {
+    it('should join messages of the whole cause chain', () => {
+      expect(describeErrorChain(chainedError()))
+        .toBe('fetch failed -> getaddrinfo ENOTFOUND swagger.internal.host');
+    });
+
+    it('should handle plain errors and non-error values', () => {
+      expect(describeErrorChain(new Error('boom'))).toBe('boom');
+      expect(describeErrorChain('just a string')).toBe('just a string');
+    });
+
+    it('should stop on circular cause chains', () => {
+      const error = new Error('loop');
+      (error as Error & { cause?: unknown }).cause = error;
+      expect(describeErrorChain(error)).toBe(['loop', 'loop', 'loop', 'loop', 'loop'].join(' -> '));
+    });
+  });
+
+  describe('formatSchematicError', () => {
+    it('should include message and stack for every cause', () => {
+      const report = formatSchematicError(chainedError());
+      expect(report).toContain('Error: TypeError: fetch failed');
+      expect(report).toContain('Caused by: Error: getaddrinfo ENOTFOUND swagger.internal.host');
+    });
+  });
+
+  describe('logSchematicError', () => {
+    it('should print the full report to console.error', () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      logSchematicError('types', chainedError());
+
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("'types' schematic failed"));
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('ENOTFOUND'));
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('wrapRuleWithErrorLogging', () => {
+    it('should log and rethrow rule failures', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const failingRule = async () => {
+        throw chainedError();
+      };
+
+      const wrapped = wrapRuleWithErrorLogging('api', failingRule as any);
+
+      await expect((wrapped as any)({}, {})).rejects.toThrow('fetch failed');
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("'api' schematic failed"));
+      consoleSpy.mockRestore();
+    });
+
+    it('should pass through successful rules untouched', async () => {
+      const wrapped = wrapRuleWithErrorLogging('api', (async () => 'result') as any);
+      await expect((wrapped as any)({}, {})).resolves.toBe('result');
+    });
+  });
+
+  describe('fetchSwaggerSchema error reporting', () => {
+    const originalFetch = globalThis.fetch;
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it('should surface the network cause chain in the error message', async () => {
+      globalThis.fetch = jest.fn().mockRejectedValue(chainedError()) as any;
+
+      await expect(fetchSwaggerSchema('https://swagger.internal.host/swagger.json'))
+        .rejects.toThrow("Failed to fetch swagger schema from 'https://swagger.internal.host/swagger.json': fetch failed -> getaddrinfo ENOTFOUND swagger.internal.host");
+    });
+
+    it('should report non-2xx responses with the URL and status', async () => {
+      globalThis.fetch = jest.fn().mockResolvedValue({ ok: false, status: 502, statusText: 'Bad Gateway' }) as any;
+
+      await expect(fetchSwaggerSchema('https://host/swagger.json'))
+        .rejects.toThrow("Failed to load swagger schema from 'https://host/swagger.json': 502 Bad Gateway");
+    });
+
+    it('should report JSON parse failures with the URL', async () => {
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.reject(new SyntaxError('Unexpected token < in JSON'))
+      }) as any;
+
+      await expect(fetchSwaggerSchema('https://host/swagger.json'))
+        .rejects.toThrow("Failed to parse swagger schema from 'https://host/swagger.json' as JSON: Unexpected token < in JSON");
+    });
+  });
+});

--- a/projects/swagger-schematics/api/index.ts
+++ b/projects/swagger-schematics/api/index.ts
@@ -23,6 +23,7 @@ import { buildAngularHttpCallArgs } from './helpers/angular-template.helper';
 import { getBaseApiImportPath } from './helpers/import-path.helper';
 import { generateBaseApiRule, DEFAULT_RTK_BASE_API_PATH } from './helpers/base-api-rules';
 import { createEslintFixRule } from '../helpers/eslint-fix.helper';
+import { wrapRuleWithErrorLogging } from '../helpers/error-logging.helper';
 import * as path from 'path';
 
 import { existsSync } from 'fs';
@@ -49,7 +50,7 @@ function loadTemplateHelpers(helpersPath: string): Record<string, unknown> {
 }
 
 export default function(options: SwaggerApiSchema) {
-    return async (tree: Tree) => {
+    const apiRule: Rule = async (tree: Tree) => {
         const config = getOpenapiSchematicsConfig(options);
 
         if (!config.path) {
@@ -129,4 +130,6 @@ export default function(options: SwaggerApiSchema) {
         const eslintFixRule = createEslintFixRule(config);
         return finalRule ? chain([finalRule, eslintFixRule]) : eslintFixRule;
     };
+
+    return wrapRuleWithErrorLogging('api', apiRule);
 }

--- a/projects/swagger-schematics/helpers/config.ts
+++ b/projects/swagger-schematics/helpers/config.ts
@@ -21,10 +21,17 @@ export const getOpenapiSchematicsConfig = (options: SwaggerApiSchema): SwaggerAp
     }, {} as SwaggerApiSchema);
 
     const config = fs.existsSync(openApiConfigFilePath) ? fs.readFileSync(openApiConfigFilePath, 'utf-8') : '{}';
-    
+
+    let parsedConfigFile: Partial<SwaggerApiSchema>;
+    try {
+        parsedConfigFile = JSON.parse(config);
+    } catch (error) {
+        throw new Error(`Failed to parse '${openApiConfigFilePath}' as JSON: ${(error as Error).message}`);
+    }
+
     const openApiSchematicsConfig: SwaggerApiSchema = {
         ...DEFAULT_CONFIG,
-        ...JSON.parse(config),
+        ...parsedConfigFile,
         ...filteredOptions
     };
     

--- a/projects/swagger-schematics/helpers/error-logging.helper.ts
+++ b/projects/swagger-schematics/helpers/error-logging.helper.ts
@@ -1,0 +1,74 @@
+import { Rule } from '@angular-devkit/schematics';
+
+const LOG_PREFIX = '[swagger-schematics]';
+const MAX_CAUSE_DEPTH = 5;
+
+/**
+ * One-line summary of an error and its cause chain.
+ * Node's fetch (undici) buries the real network reason (DNS, proxy, TLS)
+ * in error.cause, which default error printing never shows.
+ */
+export function describeErrorChain(error: unknown): string {
+    const messages: string[] = [];
+    let current: unknown = error;
+    let depth = 0;
+
+    while (current !== undefined && current !== null && depth < MAX_CAUSE_DEPTH) {
+        const err = current as { message?: unknown; cause?: unknown };
+        messages.push(typeof err.message === 'string' && err.message ? err.message : String(current));
+        current = err.cause;
+        depth++;
+    }
+
+    return messages.join(' -> ');
+}
+
+/**
+ * Full multi-line report of an error: message and stack for every
+ * link of the cause chain.
+ */
+export function formatSchematicError(error: unknown): string {
+    const lines: string[] = [];
+    let current: unknown = error;
+    let depth = 0;
+
+    while (current !== undefined && current !== null && depth < MAX_CAUSE_DEPTH) {
+        const err = current as { message?: unknown; stack?: unknown; cause?: unknown };
+        const label = depth === 0 ? 'Error' : 'Caused by';
+
+        if (typeof err.stack === 'string' && err.stack) {
+            // The stack already starts with "<name>: <message>"
+            lines.push(`${label}: ${err.stack}`);
+        } else {
+            lines.push(`${label}: ${typeof err.message === 'string' && err.message ? err.message : String(current)}`);
+        }
+
+        current = err.cause;
+        depth++;
+    }
+
+    return lines.join('\n');
+}
+
+/**
+ * Prints a full error report to the console (visible in CI logs) - schematic
+ * runners often surface only the top-level message, or nothing at all.
+ */
+export function logSchematicError(schematicName: string, error: unknown): void {
+    console.error(`${LOG_PREFIX} '${schematicName}' schematic failed:\n${formatSchematicError(error)}`);
+}
+
+/**
+ * Wraps a rule so any failure is reported in full to the console before
+ * being rethrown - generation still fails, but never silently.
+ */
+export function wrapRuleWithErrorLogging(schematicName: string, rule: Rule): Rule {
+    return async (tree, context) => {
+        try {
+            return await (rule as (tree: unknown, context: unknown) => Promise<Rule | void>)(tree, context);
+        } catch (error) {
+            logSchematicError(schematicName, error);
+            throw error;
+        }
+    };
+}

--- a/projects/swagger-schematics/helpers/swagger-schema.helper.ts
+++ b/projects/swagger-schematics/helpers/swagger-schema.helper.ts
@@ -1,11 +1,28 @@
 import { ISwaggerSchema } from '../interfaces/version_3_1/swagger.interface';
+import { describeErrorChain } from './error-logging.helper';
 
 export async function fetchSwaggerSchema(url: string): Promise<ISwaggerSchema> {
-    const response = await fetch(url);
+    console.info(`[swagger-schematics] Fetching swagger schema from '${url}'`);
+
+    let response: Response;
+    try {
+        response = await fetch(url);
+    } catch (error) {
+        // fetch failures ("fetch failed") hide the real network reason in error.cause
+        const wrapped = new Error(`Failed to fetch swagger schema from '${url}': ${describeErrorChain(error)}`);
+        (wrapped as Error & { cause?: unknown }).cause = error;
+        throw wrapped;
+    }
 
     if (!response.ok) {
         throw new Error(`Failed to load swagger schema from '${url}': ${response.status} ${response.statusText}`);
     }
 
-    return await response.json() as ISwaggerSchema;
+    try {
+        return await response.json() as ISwaggerSchema;
+    } catch (error) {
+        const wrapped = new Error(`Failed to parse swagger schema from '${url}' as JSON: ${describeErrorChain(error)}`);
+        (wrapped as Error & { cause?: unknown }).cause = error;
+        throw wrapped;
+    }
 }

--- a/projects/swagger-schematics/package.json
+++ b/projects/swagger-schematics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-schematics",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Schematics types and API generator via Swagger scheme",
   "scripts": {
     "prebuild": "json2ts -i api/schema.json -o api/schema.d.ts --no-additionalProperties && json2ts -i types/schema.json -o types/schema.d.ts --no-additionalProperties",

--- a/projects/swagger-schematics/types/index.ts
+++ b/projects/swagger-schematics/types/index.ts
@@ -19,9 +19,10 @@ import { TSwaggerSchematicsSchema } from '../interfaces/swagger-schematics/schem
 import { removeImportDuplicates, transformProperties, transformCompositionSchema } from './helpers/template.helper';
 import { getOpenapiSchematicsConfig } from '../helpers/config';
 import { createEslintFixRule } from '../helpers/eslint-fix.helper';
+import { wrapRuleWithErrorLogging } from '../helpers/error-logging.helper';
 
 export default function(options: SwaggerSchema): Rule {
-  return async (host: Tree) => {
+  const typesRule: Rule = async (host: Tree) => {
     const openApiSchematicsConfig= getOpenapiSchematicsConfig(options);
 
       let indentSize = '2';
@@ -163,4 +164,6 @@ export default function(options: SwaggerSchema): Rule {
       const eslintFixRule = createEslintFixRule(openApiSchematicsConfig);
       return finalRule ? chain([finalRule, eslintFixRule]) : eslintFixRule;
   };
+
+  return wrapRuleWithErrorLogging('types', typesRule);
 }


### PR DESCRIPTION
Patch release fixing silent generator crashes in CI (Azure Pipelines aborted generation with no output at all).

- Both schematics are wrapped with error logging: any failure prints the full report to the console - message **and stack for the whole `error.cause` chain** - before rethrowing, so generation still fails with a proper exit code but never silently
- Node `fetch` network failures now show the real reason: undici reports a bare `fetch failed` and hides DNS/proxy/TLS causes in `error.cause`, which was never printed. Now: `Failed to fetch swagger schema from '<url>': fetch failed -> getaddrinfo ENOTFOUND host`
- Invalid JSON in `openapi-schematics.json` or the downloaded schema fails with a clear message naming the file/URL
- `Fetching swagger schema from '<url>'` is logged at generation start so CI logs show how far generation got
- Version bumped to 1.0.1, changelog entry added